### PR TITLE
fix: use getAgentDir() function to support PI_CODING_AGENT_DIR config location for sandbox plugin

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -69,6 +69,7 @@ import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-age
 import {
   type BashOperations,
   createBashTool,
+  getAgentDir,
   isToolCallEventType,
 } from "@mariozechner/pi-coding-agent";
 
@@ -103,7 +104,7 @@ const DEFAULT_CONFIG: SandboxConfig = {
 
 function loadConfig(cwd: string): SandboxConfig {
   const projectConfigPath = join(cwd, ".pi", "sandbox.json");
-  const globalConfigPath = join(homedir(), ".pi", "agent", "sandbox.json");
+  const globalConfigPath = join(getAgentDir(), "sandbox.json");
 
   let globalConfig: Partial<SandboxConfig> = {};
   let projectConfig: Partial<SandboxConfig> = {};


### PR DESCRIPTION
Thanks for putting together such an awesome pi plugin! Just a small suggestion that uses the `getAgentDir()` function from the `@mariozechner/pi-coding-agent` package to support the [$PI_CODING_AGENT_DIR](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/README.md#environment-variables) environment variable that allows Pi users to set a custom path for their global Pi config folder (for me it's to `~/.config/pi`).