### PR TITLE
Fix --no-sandbox / /sandbox-disable not disabling read/write/edit blocks

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -603,13 +603,15 @@ export default function (pi: ExtensionAPI) {
   // ── tool_call — network pre-check for bash, path policy for read/write/edit
 
   pi.on("tool_call", async (event, ctx) => {
+    if (!sandboxEnabled) return;
+
     const config = loadConfig(ctx.cwd);
     if (!config.enabled) return;
 
     const { projectPath, globalPath } = getConfigPaths(ctx.cwd);
 
     // Network pre-check for bash tool calls.
-    if (sandboxEnabled && sandboxInitialized && isToolCallEventType("bash", event)) {
+    if (sandboxInitialized && isToolCallEventType("bash", event)) {
       const domains = extractDomainsFromCommand(event.input.command);
       const effectiveDomains = getEffectiveAllowedDomains(ctx.cwd);
       for (const domain of domains) {


### PR DESCRIPTION
Only `isToolCallEventType("bash", event)` was allowed with the sandbox disabled. Read/Write was still disabled despite the user using `/sandbox-disable`

Fixes https://github.com/carderne/pi-sandbox/issues/6