### PR TITLE
fix: override vulnerable lodash-es transitive dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3606,9 +3606,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/long": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "typescript": "^5"
   },
   "overrides": {
-    "minimatch": ">=10.2.1"
+    "minimatch": ">=10.2.1",
+    "lodash-es": ">=4.18.1"
   }
 }


### PR DESCRIPTION
## Summary
- add an override for `lodash-es` to force a non-vulnerable version
- refresh `package-lock.json` so git installs pick up the fixed transitive dependency

## Why
`npm audit --omit=dev` reports a high-severity vulnerability in the runtime dependency tree:

- `pi-sandbox` -> `@carderne/sandbox-runtime@0.0.43` -> `lodash-es@4.17.23`

This PR updates the resolved version to `lodash-es@4.18.1`, which clears the production/runtime audit findings.

## Validation
- `npm audit --omit=dev` => 0 vulnerabilities
- `npm run check`
- `npm run lint`
- `npm run ci:fmt`

Note: a full `npm audit` still reports dev-only issues from unrelated dependencies; this PR only addresses the runtime vulnerability reported for normal package installs.