### PR TITLE
docs(readme): document ripgrep prerequisite on macOS + Linux (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,38 @@ These open significant security loopholes, so shouldn't be used in a sensitive c
 You may need to trial and error to find additional things you need to allow.
 
 ## Quickstart
+
+#### Prerequisites
+
+`pi-sandbox` delegates the OS-level bash sandbox to
+[Anthropic Sandbox Runtime](https://github.com/anthropic-experimental/sandbox-runtime),
+which checks for [`ripgrep`](https://github.com/BurntSushi/ripgrep) (the
+`rg` binary) on **both macOS and Linux** at sandbox-init time. If `rg`
+is not on the `PATH` that pi was launched with, sandbox initialization
+fails with:
+
+```
+Sandbox initialization failed: Sandbox dependencies not available: ripgrep (rg) not found
+```
+
+Install ripgrep before enabling the extension:
+
+| Platform | Install |
+|---|---|
+| macOS (Homebrew) | `brew install ripgrep` |
+| macOS (MacPorts) | `sudo port install ripgrep` |
+| Linux (Debian/Ubuntu) | `sudo apt install ripgrep` |
+| Linux (Fedora/RHEL) | `sudo dnf install ripgrep` |
+| Linux (Arch) | `sudo pacman -S ripgrep` |
+| From source / other | <https://github.com/BurntSushi/ripgrep#installation> |
+
+If `which rg` succeeds in your shell but pi still reports `rg not
+found`, pi is being launched from a parent process whose `PATH` does
+not include the directory containing `rg` (common when GUI launchers
+inherit a minimal non-login `PATH`). On macOS, `/opt/homebrew/bin` and
+`/usr/local/bin` are the usual culprits — make sure your launcher's
+environment includes whichever one your install uses.
+
 #### Install
 ```bash
 pi install npm:pi-sandbox


### PR DESCRIPTION
Closes #19.

## Summary
\`pi-sandbox\` delegates the OS-level bash sandbox to [Anthropic Sandbox Runtime](https://github.com/anthropic-experimental/sandbox-runtime), which checks for \`ripgrep\` on **both macOS and Linux** at sandbox-init time. The previous README mentioned the underlying tool stack (\`sandbox-exec\` for macOS, \`bubblewrap\` for Linux) but did not call out the \`rg\` requirement, so users hit a confusing
```
Sandbox initialization failed: Sandbox dependencies not available: ripgrep (rg) not found
```
on first launch.

## Change
Add a `#### Prerequisites` subsection at the top of Quickstart that:
- shows the exact error message users see when `rg` is missing (so search engines surface this README on first failure);
- lists install commands for the common macOS / Linux package managers (Homebrew, MacPorts, apt, dnf, pacman), plus a link to upstream ripgrep installation docs;
- explains the GUI-launcher PATH gotcha that the issue reporter hit (`which rg` works in the user's shell but pi was started from a launcher with a minimal non-login PATH that didn't include `/opt/homebrew/bin` / `/usr/local/bin`).

## Test plan
- [x] Markdown renders cleanly in the PR preview (table + fenced code blocks).
- [x] No code changes — pure README-only fix scoped to the install path.

## Notes
- The optional `ripgrep.command` config knob mentioned in the issue is left for follow-up since it is a runtime-side change in `@anthropic/sandbox-runtime` rather than this package.