### PR TITLE
feat: wildcard for allow all domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ pi install npm:pi-sandbox
 ```
 
 #### Configure
-Add a config like this either to `~/.pi/agent` (global) or to `.pi/sandbox.json` (local).
+Add a config like this either to `~/.pi/agent/sandbox.json` (global) or to `.pi/sandbox.json` (local).
 Local config takes precedence over global.
 
 Note below that the order of precedence for filesystem read and write are opposite.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Sandbox for [pi](https://pi.dev/).
 
 Sandboxes pi like this:
 - read/write/edit: direct control using allow/deny lists
-- bash: uses [Anthropic Sandbox Runtime](https://github.com/anthropic-experimental/sandbox-runtime) to control network and file system access
+- bash: uses [`@carderne/sandbox-runtime`](https://www.npmjs.com/package/@carderne/sandbox-runtime) to control network and file system access
 
 When a blocked action is attempted, the user is
 prompted to allow it temporarily or permanently rather than silently failing.
@@ -23,8 +23,11 @@ You may need to trial and error to find additional things you need to allow.
 #### Prerequisites
 
 `pi-sandbox` delegates the OS-level bash sandbox to
-[Anthropic Sandbox Runtime](https://github.com/anthropic-experimental/sandbox-runtime),
-which checks for [`ripgrep`](https://github.com/BurntSushi/ripgrep) (the
+[`@carderne/sandbox-runtime`](https://www.npmjs.com/package/@carderne/sandbox-runtime),
+published from the fork at <https://github.com/carderne/sandbox-runtime>,
+which is forked from Anthropic's
+[`anthropic-experimental/sandbox-runtime`](https://github.com/anthropic-experimental/sandbox-runtime).
+The sandbox runtime checks for [`ripgrep`](https://github.com/BurntSushi/ripgrep) (the
 `rg` binary) on **both macOS and Linux** at sandbox-init time. If `rg`
 is not on the `PATH` that pi was launched with, sandbox initialization
 fails with:
@@ -131,7 +134,9 @@ If a path is added to `allowWrite` via a prompt but is also present in
 `denyWrite`, it remains blocked. A warning is shown explaining which config
 files to check.
 
-`allowedDomains` supports `*.example.com` wildcards. `allowWrite` uses prefix
+`allowedDomains` supports `*.example.com` wildcards. It also supports `"*"` to
+allow all domains; pi-sandbox shows a warning when this is configured because it
+removes per-domain prompts and can be easy to add accidentally. `allowWrite` uses prefix
 matching, so `.` covers the entire current working directory.
 
 > **⚠️ Read and write have different precedence rules:**

--- a/index.ts
+++ b/index.ts
@@ -64,7 +64,11 @@ import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { SandboxManager, type SandboxRuntimeConfig } from "@carderne/sandbox-runtime";
+import {
+  SandboxManager,
+  type SandboxAskCallback,
+  type SandboxRuntimeConfig,
+} from "@carderne/sandbox-runtime";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import {
   type BashOperations,
@@ -176,6 +180,7 @@ function extractDomainsFromCommand(command: string): string[] {
 }
 
 function domainMatchesPattern(domain: string, pattern: string): boolean {
+  if (pattern === "*") return true;
   if (pattern.startsWith("*.")) {
     const base = pattern.slice(2);
     return domain === base || domain.endsWith("." + base);
@@ -183,8 +188,16 @@ function domainMatchesPattern(domain: string, pattern: string): boolean {
   return domain === pattern;
 }
 
+function allowsAllDomains(allowedDomains: string[] | undefined): boolean {
+  return allowedDomains?.includes("*") ?? false;
+}
+
 function domainIsAllowed(domain: string, allowedDomains: string[]): boolean {
   return allowedDomains.some((p) => domainMatchesPattern(domain, p));
+}
+
+function createNetworkAskCallback(allowedDomains: string[]): SandboxAskCallback {
+  return async ({ host }) => domainIsAllowed(host, allowedDomains);
 }
 
 // ── Output analysis ───────────────────────────────────────────────────────────
@@ -398,23 +411,27 @@ export default function (pi: ExtensionAPI) {
     const config = loadConfig(cwd);
     const configExt = config as unknown as { allowBrowserProcess?: boolean };
     try {
+      const network = {
+        ...config.network,
+        allowedDomains: [...(config.network?.allowedDomains ?? []), ...sessionAllowedDomains],
+        deniedDomains: config.network?.deniedDomains ?? [],
+      };
       await SandboxManager.reset();
-      await SandboxManager.initialize({
-        network: {
-          ...config.network,
-          allowedDomains: [...(config.network?.allowedDomains ?? []), ...sessionAllowedDomains],
-          deniedDomains: config.network?.deniedDomains ?? [],
+      await SandboxManager.initialize(
+        {
+          network,
+          filesystem: {
+            ...config.filesystem,
+            denyRead: config.filesystem?.denyRead ?? [],
+            allowRead: config.filesystem?.allowRead ?? [],
+            allowWrite: [...(config.filesystem?.allowWrite ?? []), ...sessionAllowedWritePaths],
+            denyWrite: config.filesystem?.denyWrite ?? [],
+          },
+          allowBrowserProcess: configExt.allowBrowserProcess,
+          enableWeakerNetworkIsolation: true,
         },
-        filesystem: {
-          ...config.filesystem,
-          denyRead: config.filesystem?.denyRead ?? [],
-          allowRead: config.filesystem?.allowRead ?? [],
-          allowWrite: [...(config.filesystem?.allowWrite ?? []), ...sessionAllowedWritePaths],
-          denyWrite: config.filesystem?.denyWrite ?? [],
-        },
-        allowBrowserProcess: configExt.allowBrowserProcess,
-        enableWeakerNetworkIsolation: true,
-      });
+        createNetworkAskCallback(network.allowedDomains),
+      );
     } catch (e) {
       console.error(`Warning: Failed to reinitialize sandbox: ${e}`);
     }
@@ -471,6 +488,15 @@ export default function (pi: ExtensionAPI) {
     if (choice.startsWith("Allow for this session")) return "session";
     if (choice.startsWith("Allow for this project")) return "project";
     return "global";
+  }
+
+  function warnIfAllDomainsAllowed(ctx: ExtensionContext, config: SandboxConfig): void {
+    if (!allowsAllDomains(config.network?.allowedDomains)) return;
+    ctx.ui.notify(
+      '⚠️ Network sandbox allows all domains because network.allowedDomains contains "*". ' +
+        'Only use this intentionally; remove "*" to restore per-domain prompts.',
+      "warning",
+    );
   }
 
   // ── Apply allowance choices ─────────────────────────────────────────────────
@@ -729,14 +755,17 @@ export default function (pi: ExtensionAPI) {
         allowBrowserProcess?: boolean;
       };
 
-      await SandboxManager.initialize({
-        network: config.network,
-        filesystem: config.filesystem,
-        ignoreViolations: configExt.ignoreViolations,
-        enableWeakerNestedSandbox: configExt.enableWeakerNestedSandbox,
-        allowBrowserProcess: configExt.allowBrowserProcess,
-        enableWeakerNetworkIsolation: true,
-      });
+      await SandboxManager.initialize(
+        {
+          network: config.network,
+          filesystem: config.filesystem,
+          ignoreViolations: configExt.ignoreViolations,
+          enableWeakerNestedSandbox: configExt.enableWeakerNestedSandbox,
+          allowBrowserProcess: configExt.allowBrowserProcess,
+          enableWeakerNetworkIsolation: true,
+        },
+        createNetworkAskCallback(config.network?.allowedDomains ?? []),
+      );
 
       // Make Node's built-in fetch() honour HTTP_PROXY / HTTPS_PROXY in this
       // process and any child processes that inherit the environment.
@@ -752,11 +781,15 @@ export default function (pi: ExtensionAPI) {
       sandboxEnabled = true;
       sandboxInitialized = true;
 
-      const networkCount = config.network?.allowedDomains?.length ?? 0;
+      warnIfAllDomainsAllowed(ctx, config);
+
+      const networkLabel = allowsAllDomains(config.network?.allowedDomains)
+        ? "all domains"
+        : `${config.network?.allowedDomains?.length ?? 0} domains`;
       const writeCount = config.filesystem?.allowWrite?.length ?? 0;
       ctx.ui.setStatus(
         "sandbox",
-        ctx.ui.theme.fg("accent", `🔒 Sandbox: ${networkCount} domains, ${writeCount} write paths`),
+        ctx.ui.theme.fg("accent", `🔒 Sandbox: ${networkLabel}, ${writeCount} write paths`),
       );
     } catch (err) {
       sandboxEnabled = false;
@@ -803,26 +836,30 @@ export default function (pi: ExtensionAPI) {
           allowBrowserProcess?: boolean;
         };
 
-        await SandboxManager.initialize({
-          network: config.network,
-          filesystem: config.filesystem,
-          ignoreViolations: configExt.ignoreViolations,
-          enableWeakerNestedSandbox: configExt.enableWeakerNestedSandbox,
-          allowBrowserProcess: configExt.allowBrowserProcess,
-          enableWeakerNetworkIsolation: true,
-        });
+        await SandboxManager.initialize(
+          {
+            network: config.network,
+            filesystem: config.filesystem,
+            ignoreViolations: configExt.ignoreViolations,
+            enableWeakerNestedSandbox: configExt.enableWeakerNestedSandbox,
+            allowBrowserProcess: configExt.allowBrowserProcess,
+            enableWeakerNetworkIsolation: true,
+          },
+          createNetworkAskCallback(config.network?.allowedDomains ?? []),
+        );
 
         sandboxEnabled = true;
         sandboxInitialized = true;
 
-        const networkCount = config.network?.allowedDomains?.length ?? 0;
+        warnIfAllDomainsAllowed(ctx, config);
+
+        const networkLabel = allowsAllDomains(config.network?.allowedDomains)
+          ? "all domains"
+          : `${config.network?.allowedDomains?.length ?? 0} domains`;
         const writeCount = config.filesystem?.allowWrite?.length ?? 0;
         ctx.ui.setStatus(
           "sandbox",
-          ctx.ui.theme.fg(
-            "accent",
-            `🔒 Sandbox: ${networkCount} domains, ${writeCount} write paths`,
-          ),
+          ctx.ui.theme.fg("accent", `🔒 Sandbox: ${networkLabel}, ${writeCount} write paths`),
         );
         ctx.ui.notify("Sandbox enabled", "info");
       } catch (err) {
@@ -875,6 +912,9 @@ export default function (pi: ExtensionAPI) {
         "",
         "Network (bash + !cmd):",
         `  Allowed domains: ${config.network?.allowedDomains?.join(", ") || "(none)"}`,
+        ...(allowsAllDomains(config.network?.allowedDomains)
+          ? ['  ⚠️ "*" allows all domains and disables per-domain prompts.']
+          : []),
         `  Denied domains:  ${config.network?.deniedDomains?.join(", ") || "(none)"}`,
         ...(sessionAllowedDomains.length > 0
           ? [`  Session allowed: ${sessionAllowedDomains.join(", ")}`]

--- a/index.ts
+++ b/index.ts
@@ -69,7 +69,11 @@ import {
   type SandboxAskCallback,
   type SandboxRuntimeConfig,
 } from "@carderne/sandbox-runtime";
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type {
+  AgentToolResult,
+  ExtensionAPI,
+  ExtensionContext,
+} from "@mariozechner/pi-coding-agent";
 import {
   type BashOperations,
   createBashTool,


### PR DESCRIPTION
- Add support for `network.allowedDomains: ["*"]` to allow all outbound domains.                                                                                                                   
- Show a warning when "*" is configured, since it disables per-domain network prompts.                                                                                                           
- Update sandbox status and /sandbox output to make all-domain access visible.                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                                                    
`deniedDomains` still takes precedence via the underlying sandbox runtime, so specific domains can remain blocked even when "*" is allowed. 

## Side Changes:

- Clarify docs around `@carderne/sandbox-runtime`, its fork repo, and the Anthropic upstream (It make me itch a little bit that it is a fork but referencing in the npm to the anthropic repo).                                                                                                      
- Small change in docs for global settings.

## Example

```json
    "network": {
        "allowedDomains": [
            "*"
        ],
        "deniedDomains": [
            "www.btree.at"
        ]
    },
```

<img width="1758" height="827" alt="image" src="https://github.com/user-attachments/assets/c0741fec-798a-48fa-8322-3857467362db" />
