### PR TITLE
feat: interactive command bypass for sensitive commands

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -169,7 +169,11 @@ function getUnsandboxedCommandLevel(
   if (existsSync(projectConfigPath)) {
     try {
       const projectConfig = JSON.parse(readFileSync(projectConfigPath, "utf-8"));
-      if ((projectConfig.unsandboxedCommands as string[] | undefined)?.map(normalizeCmd).includes(normalized)) {
+      if (
+        (projectConfig.unsandboxedCommands as string[] | undefined)
+          ?.map(normalizeCmd)
+          .includes(normalized)
+      ) {
         return "project-config";
       }
     } catch {
@@ -182,7 +186,11 @@ function getUnsandboxedCommandLevel(
   if (existsSync(globalConfigPath)) {
     try {
       const globalConfig = JSON.parse(readFileSync(globalConfigPath, "utf-8"));
-      if ((globalConfig.unsandboxedCommands as string[] | undefined)?.map(normalizeCmd).includes(normalized)) {
+      if (
+        (globalConfig.unsandboxedCommands as string[] | undefined)
+          ?.map(normalizeCmd)
+          .includes(normalized)
+      ) {
         return "global-config";
       }
     } catch {
@@ -356,9 +364,24 @@ function extractBlockedWritePath(output: string): string | null {
 // ── Action label helper ───────────────────────────────────────────────────────
 
 /** Convert an Action enum to a human-readable label. */
-function actionLabel(action: "abort" | "session" | "project" | "global" | "once" | "project-config" | "global-config" | "declined"): string {
-  return action === "once" ? "once" : action === "session" ? "session"
-    : action === "project" ? "project" : "global";
+function actionLabel(
+  action:
+    | "abort"
+    | "session"
+    | "project"
+    | "global"
+    | "once"
+    | "project-config"
+    | "global-config"
+    | "declined",
+): string {
+  return action === "once"
+    ? "once"
+    : action === "session"
+      ? "session"
+      : action === "project"
+        ? "project"
+        : "global";
 }
 
 // ── Command normalization ─────────────────────────────────────────────────────
@@ -623,14 +646,30 @@ export default function (pi: ExtensionAPI) {
 
   // ── UI prompts ──────────────────────────────────────────────────────────────
 
-  type Action = "abort" | "session" | "project" | "global" | "once" | "project-config" | "global-config";
+  type Action =
+    | "abort"
+    | "session"
+    | "project"
+    | "global"
+    | "once"
+    | "project-config"
+    | "global-config";
 
   // ── Record decision + notify user + agent ───────────────────────────────────
 
   function recordDecisionAndNotify(
     ctx: ExtensionContext,
     decision: {
-      action: "bypass-predictive" | "bypass-retry" | "bypass-declined" | "domain-allowed" | "read-allowed" | "write-allowed" | "domain-denied" | "read-denied" | "write-denied";
+      action:
+        | "bypass-predictive"
+        | "bypass-retry"
+        | "bypass-declined"
+        | "domain-allowed"
+        | "read-allowed"
+        | "write-allowed"
+        | "domain-denied"
+        | "read-denied"
+        | "write-denied";
       target: string;
       choice: string;
     },
@@ -639,8 +678,7 @@ export default function (pi: ExtensionAPI) {
 
     const auditType: "predictive" | "reactive" =
       action === "bypass-predictive" ? "predictive" : "reactive";
-    const unsandboxed =
-      action === "bypass-predictive" || action === "bypass-retry";
+    const unsandboxed = action === "bypass-predictive" || action === "bypass-retry";
 
     auditLog({
       timestamp: new Date().toISOString(),
@@ -774,130 +812,125 @@ export default function (pi: ExtensionAPI) {
   ): Promise<Action> {
     if (!ctx.hasUI) return "abort";
 
-    const result = await ctx.ui.custom<Action>(
-      (tui, theme, _kb, done) => {
-        let selectedIndex = 0;
-        let pendingAction: Action | null = null;
-        let renderedAt = 0;
-        const DEBOUNCE_MS = 400;
+    const result = await ctx.ui.custom<Action>((tui, theme, _kb, done) => {
+      let selectedIndex = 0;
+      let pendingAction: Action | null = null;
+      let renderedAt = 0;
+      const DEBOUNCE_MS = 400;
 
-        function resolve(action: Action) {
-          done(action);
-        }
+      function resolve(action: Action) {
+        done(action);
+      }
 
-        return {
-          render(width: number): string[] {
-            if (renderedAt === 0) renderedAt = Date.now();
-            const lines: string[] = [];
-            lines.push(truncateToWidth(theme.fg("warning", title), width));
-            lines.push("");
+      return {
+        render(width: number): string[] {
+          if (renderedAt === 0) renderedAt = Date.now();
+          const lines: string[] = [];
+          lines.push(truncateToWidth(theme.fg("warning", title), width));
+          lines.push("");
 
-            for (let i = 0; i < options.length; i++) {
-              const opt = options[i];
-              const isSelected = i === selectedIndex;
-              const isPending = pendingAction === opt.action;
+          for (let i = 0; i < options.length; i++) {
+            const opt = options[i];
+            const isSelected = i === selectedIndex;
+            const isPending = pendingAction === opt.action;
 
-              const prefix = isSelected ? " → " : "   ";
-              const keyHint = theme.fg("accent", `[${opt.key}]`);
-              let label = opt.label;
+            const prefix = isSelected ? " → " : "   ";
+            const keyHint = theme.fg("accent", `[${opt.key}]`);
+            let label = opt.label;
 
-              if (opt.hint) {
-                label += `  ${theme.fg("dim", opt.hint)}`;
-              }
-
-              if (isPending) {
-                label += `  ${theme.fg("warning", "→ press Enter to confirm")}`;
-              }
-
-              const line = `${prefix}${keyHint} ${label}`;
-              lines.push(truncateToWidth(line, width));
+            if (opt.hint) {
+              label += `  ${theme.fg("dim", opt.hint)}`;
             }
 
-            lines.push("");
-            const hasEsc = options.some((o) => o.key === "esc");
-            const abortKeys = hasEsc ? "esc/ctrl+c" : "q/ctrl+c";
-            const footer = pendingAction
-              ? `↑↓ navigate  enter confirm  ${abortKeys.split("/")[0]} abort`
-              : `↑↓ navigate  enter select  ${abortKeys} abort`;
-            lines.push(truncateToWidth(theme.fg("dim", footer), width));
+            if (isPending) {
+              label += `  ${theme.fg("warning", "→ press Enter to confirm")}`;
+            }
 
-            return lines;
-          },
+            const line = `${prefix}${keyHint} ${label}`;
+            lines.push(truncateToWidth(line, width));
+          }
 
-          handleInput(data: string): void {
-            // NOTE: pi routes ALL keyboard input to this component when focused.
-            // App-level keys like Ctrl+O (expand) are NOT processed. Workaround:
-            // esc to dismiss, expand tool output, then re-trigger the prompt.
+          lines.push("");
+          const hasEsc = options.some((o) => o.key === "esc");
+          const abortKeys = hasEsc ? "esc/ctrl+c" : "q/ctrl+c";
+          const footer = pendingAction
+            ? `↑↓ navigate  enter confirm  ${abortKeys.split("/")[0]} abort`
+            : `↑↓ navigate  enter select  ${abortKeys} abort`;
+          lines.push(truncateToWidth(theme.fg("dim", footer), width));
 
-            // Debounce: ignore single-key presses for DEBOUNCE_MS after prompt appears.
-            // Prevents accidental selection when user is typing in chat text box.
-            // Navigation keys (arrows, enter, escape) are always allowed.
-            if (Date.now() - renderedAt < DEBOUNCE_MS && !isNavigationKey(data)) {
+          return lines;
+        },
+
+        handleInput(data: string): void {
+          // NOTE: pi routes ALL keyboard input to this component when focused.
+          // App-level keys like Ctrl+O (expand) are NOT processed. Workaround:
+          // esc to dismiss, expand tool output, then re-trigger the prompt.
+
+          // Debounce: ignore single-key presses for DEBOUNCE_MS after prompt appears.
+          // Prevents accidental selection when user is typing in chat text box.
+          // Navigation keys (arrows, enter, escape) are always allowed.
+          if (Date.now() - renderedAt < DEBOUNCE_MS && !isNavigationKey(data)) {
+            return;
+          }
+
+          if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
+            resolve("abort");
+            return;
+          }
+
+          if (matchesKey(data, Key.enter)) {
+            if (pendingAction) {
+              resolve(pendingAction);
+            } else {
+              resolve(options[selectedIndex]?.action ?? "abort");
+            }
+            return;
+          }
+
+          if (matchesKey(data, Key.up)) {
+            selectedIndex = Math.max(0, selectedIndex - 1);
+            pendingAction = null;
+            tui.requestRender();
+            return;
+          }
+          if (matchesKey(data, Key.down)) {
+            selectedIndex = Math.min(options.length - 1, selectedIndex + 1);
+            pendingAction = null;
+            tui.requestRender();
+            return;
+          }
+
+          for (let i = 0; i < options.length; i++) {
+            const opt = options[i];
+            if (data === opt.key) {
+              // Exact case match → immediate
+              resolve(opt.action);
               return;
             }
-
-            if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
-              resolve("abort");
-              return;
-            }
-
-            if (matchesKey(data, Key.enter)) {
-              if (pendingAction) {
-                resolve(pendingAction);
+            if (data.toLowerCase() === opt.key.toLowerCase()) {
+              // Lowercase match → confirmation required for P/A
+              if (opt.confirm) {
+                pendingAction = opt.action;
+                selectedIndex = i;
               } else {
-                resolve(options[selectedIndex]?.action ?? "abort");
-              }
-              return;
-            }
-
-            if (matchesKey(data, Key.up)) {
-              selectedIndex = Math.max(0, selectedIndex - 1);
-              pendingAction = null;
-              tui.requestRender();
-              return;
-            }
-            if (matchesKey(data, Key.down)) {
-              selectedIndex = Math.min(options.length - 1, selectedIndex + 1);
-              pendingAction = null;
-              tui.requestRender();
-              return;
-            }
-
-            for (let i = 0; i < options.length; i++) {
-              const opt = options[i];
-              if (data === opt.key) {
-                // Exact case match → immediate
                 resolve(opt.action);
-                return;
               }
-              if (data.toLowerCase() === opt.key.toLowerCase()) {
-                // Lowercase match → confirmation required for P/A
-                if (opt.confirm) {
-                  pendingAction = opt.action;
-                  selectedIndex = i;
-                } else {
-                  resolve(opt.action);
-                }
-                tui.requestRender();
-                return;
-              }
+              tui.requestRender();
+              return;
             }
-          },
+          }
+        },
 
-          invalidate(): void {
-            // no-op
-          },
-        };
-      },
-    );
+        invalidate(): void {
+          // no-op
+        },
+      };
+    });
 
     return result ?? "abort";
   }
 
-  async function promptDomainBlock(
-    ctx: ExtensionContext,
-    domain: string,
-  ): Promise<Action> {
+  async function promptDomainBlock(ctx: ExtensionContext, domain: string): Promise<Action> {
     return showPermissionPrompt(
       ctx,
       `🌐 Network blocked: "${domain}" is not in allowedDomains`,
@@ -905,10 +938,7 @@ export default function (pi: ExtensionAPI) {
     ) as Promise<Action>;
   }
 
-  async function promptReadBlock(
-    ctx: ExtensionContext,
-    filePath: string,
-  ): Promise<Action> {
+  async function promptReadBlock(ctx: ExtensionContext, filePath: string): Promise<Action> {
     return showPermissionPrompt(
       ctx,
       `📖 Read blocked: "${filePath}" is not in allowRead`,
@@ -916,10 +946,7 @@ export default function (pi: ExtensionAPI) {
     ) as Promise<Action>;
   }
 
-  async function promptWriteBlock(
-    ctx: ExtensionContext,
-    filePath: string,
-  ): Promise<Action> {
+  async function promptWriteBlock(ctx: ExtensionContext, filePath: string): Promise<Action> {
     return showPermissionPrompt(
       ctx,
       `📝 Write blocked: "${filePath}" is not in allowWrite`,
@@ -952,11 +979,7 @@ export default function (pi: ExtensionAPI) {
 
   // ── Apply allowance choices ─────────────────────────────────────────────────
 
-  async function applyDomainChoice(
-    choice: Action,
-    domain: string,
-    cwd: string,
-  ): Promise<void> {
+  async function applyDomainChoice(choice: Action, domain: string, cwd: string): Promise<void> {
     const { globalPath, projectPath } = getConfigPaths(cwd);
     if (choice === "session") sessionAllowedDomains.push(domain);
     if (choice === "project") addDomainToConfig(projectPath, domain);
@@ -973,11 +996,7 @@ export default function (pi: ExtensionAPI) {
     await reinitializeSandbox(cwd);
   }
 
-  async function applyReadChoice(
-    choice: Action,
-    filePath: string,
-    cwd: string,
-  ): Promise<void> {
+  async function applyReadChoice(choice: Action, filePath: string, cwd: string): Promise<void> {
     const { globalPath, projectPath } = getConfigPaths(cwd);
     if (choice === "session") sessionAllowedReadPaths.push(filePath);
     if (choice === "project") addReadPathToConfig(projectPath, filePath);
@@ -994,11 +1013,7 @@ export default function (pi: ExtensionAPI) {
     await reinitializeSandbox(cwd);
   }
 
-  async function applyWriteChoice(
-    choice: Action,
-    filePath: string,
-    cwd: string,
-  ): Promise<void> {
+  async function applyWriteChoice(choice: Action, filePath: string, cwd: string): Promise<void> {
     const { globalPath, projectPath } = getConfigPaths(cwd);
     if (choice === "session") sessionAllowedWritePaths.push(filePath);
     if (choice === "project") addWritePathToConfig(projectPath, filePath);
@@ -1440,31 +1455,31 @@ export default function (pi: ExtensionAPI) {
   async function restoreSessionState(ctx: ExtensionContext): Promise<void> {
     try {
       for (const entry of ctx.sessionManager.getEntries()) {
-      if (entry.type === "custom" && entry.customType === "sandbox-session") {
-        const data = entry.data as {
-          sessionAllowedDomains?: string[];
-          sessionAllowedReadPaths?: string[];
-          sessionAllowedWritePaths?: string[];
-          sessionUnsandboxedCommands?: string[];
-        };
-        if (data.sessionAllowedDomains) {
-          sessionAllowedDomains.length = 0;
-          sessionAllowedDomains.push(...data.sessionAllowedDomains);
-        }
-        if (data.sessionAllowedReadPaths) {
-          sessionAllowedReadPaths.length = 0;
-          sessionAllowedReadPaths.push(...data.sessionAllowedReadPaths);
-        }
-        if (data.sessionAllowedWritePaths) {
-          sessionAllowedWritePaths.length = 0;
-          sessionAllowedWritePaths.push(...data.sessionAllowedWritePaths);
-        }
-        if (data.sessionUnsandboxedCommands) {
-          sessionUnsandboxedCommands.length = 0;
-          sessionUnsandboxedCommands.push(...data.sessionUnsandboxedCommands);
+        if (entry.type === "custom" && entry.customType === "sandbox-session") {
+          const data = entry.data as {
+            sessionAllowedDomains?: string[];
+            sessionAllowedReadPaths?: string[];
+            sessionAllowedWritePaths?: string[];
+            sessionUnsandboxedCommands?: string[];
+          };
+          if (data.sessionAllowedDomains) {
+            sessionAllowedDomains.length = 0;
+            sessionAllowedDomains.push(...data.sessionAllowedDomains);
+          }
+          if (data.sessionAllowedReadPaths) {
+            sessionAllowedReadPaths.length = 0;
+            sessionAllowedReadPaths.push(...data.sessionAllowedReadPaths);
+          }
+          if (data.sessionAllowedWritePaths) {
+            sessionAllowedWritePaths.length = 0;
+            sessionAllowedWritePaths.push(...data.sessionAllowedWritePaths);
+          }
+          if (data.sessionUnsandboxedCommands) {
+            sessionUnsandboxedCommands.length = 0;
+            sessionUnsandboxedCommands.push(...data.sessionUnsandboxedCommands);
+          }
         }
       }
-    }
     } catch {
       // Silently ignore restoration errors — sandbox init proceeds without session state
     }

--- a/index.ts
+++ b/index.ts
@@ -1047,25 +1047,11 @@ export default function (pi: ExtensionAPI) {
       ) {
         const displayCmd = truncateCmd(command);
         const level = getUnsandboxedCommandLevel(command, ctx.cwd, sessionUnsandboxedCommands);
-        ctx.ui.notify(`🔓 Sandbox disabled: "${displayCmd}" (${level} config)`, "warning");
-        auditLog({
-          timestamp: new Date().toISOString(),
-          command: normalizeCmd(command),
-          type: "predictive",
+        recordDecisionAndNotify(ctx, {
+          action: "bypass-predictive",
+          target: displayCmd,
           choice: level,
-          unsandboxed: true,
         });
-        pi.sendMessage(
-          {
-            customType: "sandbox-bypass",
-            content: `User pre-configured unsandboxed execution of exact command "${displayCmd}" (${level})`,
-            display: false,
-          },
-          {
-            deliverAs: "steer",
-            triggerTurn: false,
-          },
-        );
         result = await runUnsandboxed();
       } else if (!sandboxEnabled || !sandboxInitialized) {
         result = await runUnsandboxed();
@@ -1102,24 +1088,10 @@ export default function (pi: ExtensionAPI) {
 
           if (choice === "abort") {
             const displayCmd = truncateCmd(command);
-            ctx.ui.notify(`🛡️  Kept sandboxed: "${displayCmd}"`, "info");
-            pi.sendMessage(
-              {
-                customType: "sandbox-bypass",
-                content: `User declined unsandboxed retry of "${displayCmd}"`,
-                display: false,
-              },
-              {
-                deliverAs: "steer",
-                triggerTurn: false,
-              },
-            );
-            auditLog({
-              timestamp: new Date().toISOString(),
-              command: normalizeCmd(command),
-              type: "reactive",
+            recordDecisionAndNotify(ctx, {
+              action: "bypass-declined",
+              target: displayCmd,
               choice: "declined",
-              unsandboxed: false,
             });
           } else {
             const displayCmd = truncateCmd(command);
@@ -1137,28 +1109,10 @@ export default function (pi: ExtensionAPI) {
 
             const bypassLabel = actionLabel(choice);
 
-            ctx.ui.notify(
-              `🔓 Retried without sandbox: "${displayCmd}" (exact match, ${bypassLabel})`,
-              "warning",
-            );
-
-            pi.sendMessage(
-              {
-                customType: "sandbox-bypass",
-                content: `User retried "${displayCmd}" without sandbox (exact match, ${bypassLabel})`,
-                display: false,
-              },
-              {
-                deliverAs: "steer",
-                triggerTurn: false,
-              },
-            );
-            auditLog({
-              timestamp: new Date().toISOString(),
-              command: normalized,
-              type: "reactive",
-              choice: choice,
-              unsandboxed: true,
+            recordDecisionAndNotify(ctx, {
+              action: "bypass-retry",
+              target: displayCmd,
+              choice: bypassLabel,
             });
 
             result = await runUnsandboxed();
@@ -1174,21 +1128,10 @@ export default function (pi: ExtensionAPI) {
           if (choice !== "abort") {
             await applyWriteChoice(choice, blockedPath, ctx.cwd);
             const level = actionLabel(choice);
-            ctx.ui.notify(`📝 Write path "${blockedPath}" allowed (${level})`, "info");
-            pi.sendMessage(
-              {
-                customType: "sandbox-permission",
-                content: `User allowed write path "${blockedPath}" (${level})`,
-                display: false,
-              },
-              { deliverAs: "steer", triggerTurn: false },
-            );
-            auditLog({
-              timestamp: new Date().toISOString(),
-              command: blockedPath,
-              type: "predictive",
-              choice,
-              unsandboxed: false,
+            recordDecisionAndNotify(ctx, {
+              action: "write-allowed",
+              target: blockedPath,
+              choice: level,
             });
 
             const config = loadConfig(ctx.cwd);
@@ -1243,21 +1186,10 @@ export default function (pi: ExtensionAPI) {
         }
         await applyDomainChoice(choice, domain, ctx.cwd);
         const level = actionLabel(choice);
-        ctx.ui.notify(`🌐 Domain "${domain}" allowed (${level})`, "info");
-        pi.sendMessage(
-          {
-            customType: "sandbox-permission",
-            content: `User allowed domain "${domain}" (${level})`,
-            display: false,
-          },
-          { deliverAs: "steer", triggerTurn: false },
-        );
-        auditLog({
-          timestamp: new Date().toISOString(),
-          command: domain,
-          type: "predictive",
-          choice,
-          unsandboxed: false,
+        recordDecisionAndNotify(ctx, {
+          action: "domain-allowed",
+          target: domain,
+          choice: level,
         });
       }
     }
@@ -1267,25 +1199,11 @@ export default function (pi: ExtensionAPI) {
     if (commandIsUnsandboxed(event.command, unsandboxedPatterns)) {
       const displayCmd = truncateCmd(event.command);
       const level = getUnsandboxedCommandLevel(event.command, ctx.cwd, sessionUnsandboxedCommands);
-      ctx.ui.notify(`🔓 Sandbox disabled: "${displayCmd}" (${level} config)`, "warning");
-      auditLog({
-        timestamp: new Date().toISOString(),
-        command: normalizeCmd(event.command),
-        type: "predictive",
+      recordDecisionAndNotify(ctx, {
+        action: "bypass-predictive",
+        target: displayCmd,
         choice: level,
-        unsandboxed: true,
       });
-      pi.sendMessage(
-        {
-          customType: "sandbox-bypass",
-          content: `User pre-configured unsandboxed execution of exact command "${displayCmd}" (${level})`,
-          display: false,
-        },
-        {
-          deliverAs: "steer",
-          triggerTurn: false,
-        },
-      );
       return; // Let default (unsandboxed) bash run
     }
 
@@ -1316,24 +1234,10 @@ export default function (pi: ExtensionAPI) {
 
       if (choice === "abort") {
         const displayCmd = truncateCmd(event.command);
-        ctx.ui.notify(`🛡️  Kept sandboxed: "${displayCmd}"`, "info");
-        pi.sendMessage(
-          {
-            customType: "sandbox-bypass",
-            content: `User declined unsandboxed retry of "${displayCmd}"`,
-            display: false,
-          },
-          {
-            deliverAs: "steer",
-            triggerTurn: false,
-          },
-        );
-        auditLog({
-          timestamp: new Date().toISOString(),
-          command: normalizeCmd(event.command),
-          type: "reactive",
+        recordDecisionAndNotify(ctx, {
+          action: "bypass-declined",
+          target: displayCmd,
           choice: "declined",
-          unsandboxed: false,
         });
       } else {
         const normalized = normalizeCmd(event.command);
@@ -1352,28 +1256,10 @@ export default function (pi: ExtensionAPI) {
         const bypassLabel = actionLabel(choice);
         const displayCmd = truncateCmd(event.command);
 
-        ctx.ui.notify(
-          `🔓 Retried without sandbox: "${displayCmd}" (exact match, ${bypassLabel})`,
-          "warning",
-        );
-
-        pi.sendMessage(
-          {
-            customType: "sandbox-bypass",
-            content: `User retried "${displayCmd}" without sandbox (exact match, ${bypassLabel})`,
-            display: false,
-          },
-          {
-            deliverAs: "steer",
-            triggerTurn: false,
-          },
-        );
-        auditLog({
-          timestamp: new Date().toISOString(),
-          command: normalized,
-          type: "reactive",
-          choice: choice,
-          unsandboxed: true,
+        recordDecisionAndNotify(ctx, {
+          action: "bypass-retry",
+          target: displayCmd,
+          choice: bypassLabel,
         });
 
         // Rerun unsandboxed
@@ -1428,21 +1314,10 @@ export default function (pi: ExtensionAPI) {
           }
           await applyDomainChoice(choice, domain, ctx.cwd);
           const level = actionLabel(choice);
-          ctx.ui.notify(`🌐 Domain "${domain}" allowed (${level})`, "info");
-          pi.sendMessage(
-            {
-              customType: "sandbox-permission",
-              content: `User allowed domain "${domain}" (${level})`,
-              display: false,
-            },
-            { deliverAs: "steer", triggerTurn: false },
-          );
-          auditLog({
-            timestamp: new Date().toISOString(),
-            command: domain,
-            type: "predictive",
-            choice,
-            unsandboxed: false,
+          recordDecisionAndNotify(ctx, {
+            action: "domain-allowed",
+            target: domain,
+            choice: level,
           });
         }
       }
@@ -1468,21 +1343,10 @@ export default function (pi: ExtensionAPI) {
         }
         await applyReadChoice(choice, filePath, ctx.cwd);
         const level = actionLabel(choice);
-        ctx.ui.notify(`📖 Read path "${filePath}" allowed (${level})`, "info");
-        pi.sendMessage(
-          {
-            customType: "sandbox-permission",
-            content: `User allowed read path "${filePath}" (${level})`,
-            display: false,
-          },
-          { deliverAs: "steer", triggerTurn: false },
-        );
-        auditLog({
-          timestamp: new Date().toISOString(),
-          command: filePath,
-          type: "predictive",
-          choice,
-          unsandboxed: false,
+        recordDecisionAndNotify(ctx, {
+          action: "read-allowed",
+          target: filePath,
+          choice: level,
         });
         // Allowed — fall through, tool runs.
         return;
@@ -1505,21 +1369,10 @@ export default function (pi: ExtensionAPI) {
         }
         await applyWriteChoice(choice, path, ctx.cwd);
         const level = actionLabel(choice);
-        ctx.ui.notify(`📝 Write path "${path}" allowed (${level})`, "info");
-        pi.sendMessage(
-          {
-            customType: "sandbox-permission",
-            content: `User allowed write path "${path}" (${level})`,
-            display: false,
-          },
-          { deliverAs: "steer", triggerTurn: false },
-        );
-        auditLog({
-          timestamp: new Date().toISOString(),
-          command: path,
-          type: "predictive",
-          choice,
-          unsandboxed: false,
+        recordDecisionAndNotify(ctx, {
+          action: "write-allowed",
+          target: path,
+          choice: level,
         });
 
         // denyWrite takes precedence — warn if it would still block.

--- a/index.ts
+++ b/index.ts
@@ -152,7 +152,6 @@ function auditLog(entry: {
 
 /**
  * Determine the config level for an unsandboxed command.
- * Determine the config level for an unsandboxed command.
  * Returns "project-config", "global-config", or "session" based on which config
  * contains the command. "-config" suffix means no user interaction occurred.
  */

--- a/index.ts
+++ b/index.ts
@@ -2,8 +2,7 @@
  * Based on https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/examples/extensions/sandbox/index.ts
  * by Mario Zechner, used under the MIT License.
  *
- * Sandbox Extension - OS-level sandboxing for bash commands, plus path policy
- * enforcement for pi's read/write/edit tools, with interactive permission prompts.
+ * Sandbox Extension - OS-level sandboxing for pi with interactive permission prompts.
  *
  * Uses @carderne/sandbox-runtime to enforce filesystem and network
  * restrictions on bash commands at the OS level (sandbox-exec on macOS,
@@ -79,6 +78,7 @@ import {
 import {
   type BashOperations,
   createBashTool,
+  createLocalBashOperations,
   getAgentDir,
   isToolCallEventType,
 } from "@mariozechner/pi-coding-agent";
@@ -86,10 +86,21 @@ import { matchesKey, Key, truncateToWidth } from "@mariozechner/pi-tui";
 
 interface SandboxConfig extends SandboxRuntimeConfig {
   enabled?: boolean;
+  /**
+   * Commands that always run unsandboxed (e.g. ["gh", "security"]).
+   * Matched by first word; persists across sessions.
+   */
+  unsandboxedCommands?: string[];
+  /**
+   * Patterns that trigger the reactive bypass prompt when found in
+   * sandboxed command output. Case-insensitive substring match.
+   */
+  sandboxFailurePatterns?: string[];
 }
 
 const DEFAULT_CONFIG: SandboxConfig = {
   enabled: true,
+  unsandboxedCommands: [],
   network: {
     allowedDomains: [
       "npmjs.org",
@@ -109,9 +120,73 @@ const DEFAULT_CONFIG: SandboxConfig = {
     denyRead: ["/Users", "/home"],
     allowRead: [".", "~/.config", "~/.local", "Library"],
     allowWrite: [".", "/tmp"],
-    denyWrite: [".env", ".env.*", "*.pem", "*.key"],
+    denyWrite: [".env", ".env.*", "*.pem", "*.key", ".pi/sandbox.json", "~/.pi/agent/sandbox.json"],
   },
 };
+
+const AUDIT_LOG = join(homedir(), ".pi", "sandbox", "audit.log");
+function auditLog(entry: {
+  timestamp: string;
+  command: string;
+  type: "predictive" | "reactive";
+  choice: "once" | "session" | "project" | "global" | "project-level" | "system-level" | "declined";
+  unsandboxed: boolean;
+}): void {
+  try {
+    mkdirSync(dirname(AUDIT_LOG), { recursive: true });
+    const line = `${JSON.stringify(entry)}\n`;
+    writeFileSync(AUDIT_LOG, line, { flag: "a" });
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Determine the config level for an unsandboxed command.
+ * Returns "project-level", "system-level", or "session" based on which config
+ * contains the command.
+ */
+function getUnsandboxedCommandLevel(
+  command: string,
+  cwd: string,
+  sessionCommands: string[],
+): "project-level" | "system-level" | "session" {
+  const normalized = command.trimStart().split(/\s+/).join(" ");
+
+  // Check session first
+  if (sessionCommands.includes(normalized)) {
+    return "session";
+  }
+
+  // Check project config
+  const projectConfigPath = join(cwd, ".pi", "sandbox.json");
+  if (existsSync(projectConfigPath)) {
+    try {
+      const projectConfig = JSON.parse(readFileSync(projectConfigPath, "utf-8"));
+      if (projectConfig.unsandboxedCommands?.includes(normalized)) {
+        return "project-level";
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  // Check global config
+  const globalConfigPath = join(getAgentDir(), "sandbox.json");
+  if (existsSync(globalConfigPath)) {
+    try {
+      const globalConfig = JSON.parse(readFileSync(globalConfigPath, "utf-8"));
+      if (globalConfig.unsandboxedCommands?.includes(normalized)) {
+        return "system-level";
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  // Fallback — shouldn't happen if commandIsUnsandboxed matched
+  return "project-level";
+}
 
 function loadConfig(cwd: string): SandboxConfig {
   const projectConfigPath = join(cwd, ".pi", "sandbox.json");
@@ -170,6 +245,16 @@ function deepMerge(base: SandboxConfig, overrides: Partial<SandboxConfig>): Sand
   if (extOverrides.allowBrowserProcess !== undefined) {
     extResult.allowBrowserProcess = extOverrides.allowBrowserProcess;
   }
+  if (overrides.unsandboxedCommands !== undefined) {
+    const baseSet = new Set(result.unsandboxedCommands ?? []);
+    for (const cmd of overrides.unsandboxedCommands) baseSet.add(cmd);
+    result.unsandboxedCommands = [...baseSet];
+  }
+  if (overrides.sandboxFailurePatterns !== undefined) {
+    const baseSet = new Set(result.sandboxFailurePatterns ?? []);
+    for (const pat of overrides.sandboxFailurePatterns) baseSet.add(pat);
+    result.sandboxFailurePatterns = [...baseSet];
+  }
 
   return result;
 }
@@ -216,12 +301,46 @@ function createNetworkAskCallback(allowedDomains: string[]): SandboxAskCallback 
   return async ({ host }) => domainIsAllowed(host, allowedDomains);
 }
 
+// ── Sandbox failure detection ───────────────────────────────────────────────
+
+/**
+ * Default patterns that indicate a sandbox/auth/keychain failure.
+ * Users can override/extend these in their sandbox.json config.
+ */
+const DEFAULT_FAILURE_PATTERNS: string[] = [
+  "operation not permitted",
+  "no oauth token",
+  "authentication failed",
+  "user interaction is not allowed",
+  "errsecinteractionnotallowed",
+  "terminal prompts disabled",
+  "could not read username",
+  "permission denied",
+];
+
+/**
+ * Check if a command starts with any of the unsandboxed patterns.
+ */
+function commandIsUnsandboxed(command: string, patterns: string[]): boolean {
+  const normalized = command.trimStart().split(/\s+/).join(" ");
+  return patterns.some((p) => normalized === p);
+}
+
+/**
+ * Detect if a command failed due to OS sandbox restrictions.
+ * This is reactive: we run sandboxed first, then check the output.
+ */
+function isSandboxFailure(output: string, patterns: string[]): boolean {
+  const lower = output.toLowerCase();
+  return patterns.some((p) => lower.includes(p.toLowerCase()));
+}
+
 // ── Output analysis ───────────────────────────────────────────────────────────
 
 /** Extract a path from a bash "Operation not permitted" OS sandbox error. */
 function extractBlockedWritePath(output: string): string | null {
   const match = output.match(
-    /(?:\/bin\/bash|bash|sh): (?:line \d: )?(\/[^\s:]+): Operation not permitted/,
+    /(?:\/bin\/bash|bash|sh): (?:line \d: )?(\/[^:]+): Operation not permitted/,
   );
   return match ? match[1] : null;
 }
@@ -311,6 +430,16 @@ function addWritePathToConfig(configPath: string, pathToAdd: string): void {
   }
 }
 
+function addUnsandboxedCommandToConfig(configPath: string, command: string): void {
+  const config = readOrEmptyConfig(configPath);
+  const existing = config.unsandboxedCommands ?? [];
+  const normalized = command.trimStart().split(/\s+/).join(" ");
+  if (normalized && !existing.includes(normalized)) {
+    config.unsandboxedCommands = [...existing, normalized];
+    writeConfigFile(configPath, config);
+  }
+}
+
 // ── Sandboxed bash ops ────────────────────────────────────────────────────────
 
 function createSandboxedBashOps(): BashOperations {
@@ -325,7 +454,11 @@ function createSandboxedBashOps(): BashOperations {
       return new Promise((resolve, reject) => {
         const child = spawn("bash", ["-c", wrappedCommand], {
           cwd,
-          env,
+          env: {
+            ...env,
+            GIT_TERMINAL_PROMPT: "0",
+            SSH_ASKPASS_REQUIRE: "never",
+          },
           detached: true,
           stdio: ["ignore", "pipe", "pipe"],
         });
@@ -421,6 +554,14 @@ export default function (pi: ExtensionAPI) {
     return [...(config.filesystem?.allowWrite ?? []), ...sessionAllowedWritePaths];
   }
 
+  // Session-only unsandboxed command patterns — JS memory only, agent cannot access.
+  const sessionUnsandboxedCommands: string[] = [];
+
+  function getEffectiveUnsandboxedCommands(cwd: string): string[] {
+    const config = loadConfig(cwd);
+    return [...(config.unsandboxedCommands ?? []), ...sessionUnsandboxedCommands];
+  }
+
   // ── Sandbox reinitialize ────────────────────────────────────────────────────
   // Called after granting a session/permanent allowance so the OS-level sandbox
   // picks up the new rules before the next bash subprocess starts.
@@ -461,12 +602,13 @@ export default function (pi: ExtensionAPI) {
   interface PromptOption {
     label: string;
     key: string;
-    action: "abort" | "session" | "project" | "global";
+    action: "abort" | "session" | "project" | "global" | "once";
     confirm?: boolean;
     hint?: string;
   }
 
   const PERMISSION_OPTIONS: PromptOption[] = [
+    { label: "Allow once", key: "o", action: "once" },
     { label: "Allow for this session only", key: "s", action: "session" },
     { label: "Abort (keep blocked)", key: "esc", action: "abort" },
     {
@@ -485,19 +627,39 @@ export default function (pi: ExtensionAPI) {
     },
   ];
 
+  const BYPASS_OPTIONS: PromptOption[] = [
+    { label: "Abort (keep failed result)", key: "esc", action: "abort" },
+    { label: "Retry without sandbox (once)", key: "o", action: "once" },
+    { label: "Retry without sandbox in this session", key: "s", action: "session" },
+    {
+      label: "Retry without sandbox for this project",
+      key: "P",
+      action: "project",
+      confirm: true,
+      hint: "→ .pi/sandbox.json",
+    },
+    {
+      label: "Retry without sandbox for all projects",
+      key: "A",
+      action: "global",
+      confirm: true,
+      hint: "→ ~/.pi/agent/sandbox.json",
+    },
+  ];
+
   async function showPermissionPrompt(
     ctx: ExtensionContext,
     title: string,
     options: PromptOption[],
-  ): Promise<"abort" | "session" | "project" | "global"> {
+  ): Promise<"abort" | "session" | "project" | "global" | "once"> {
     if (!ctx.hasUI) return "abort";
 
-    const result = await ctx.ui.custom<"abort" | "session" | "project" | "global">(
+    const result = await ctx.ui.custom<"abort" | "session" | "project" | "global" | "once">(
       (tui, theme, _kb, done) => {
         let selectedIndex = 0;
-        let pendingAction: "abort" | "session" | "project" | "global" | null = null;
+        let pendingAction: "abort" | "session" | "project" | "global" | "once" | null = null;
 
-        function resolve(action: "abort" | "session" | "project" | "global") {
+        function resolve(action: "abort" | "session" | "project" | "global" | "once") {
           done(action);
         }
 
@@ -529,9 +691,11 @@ export default function (pi: ExtensionAPI) {
             }
 
             lines.push("");
+            const hasEsc = options.some((o) => o.key === "esc");
+            const abortKeys = hasEsc ? "esc/ctrl+c" : "q/ctrl+c";
             const footer = pendingAction
-              ? "↑↓ navigate  enter confirm  esc cancel"
-              : "↑↓ navigate  enter select  esc/ctrl+c cancel";
+              ? `↑↓ navigate  enter confirm  ${abortKeys.split("/")[0]} abort`
+              : `↑↓ navigate  enter select  ${abortKeys} abort`;
             lines.push(truncateToWidth(theme.fg("dim", footer), width));
 
             return lines;
@@ -568,7 +732,7 @@ export default function (pi: ExtensionAPI) {
             for (let i = 0; i < options.length; i++) {
               const opt = options[i];
               if (data === opt.key) {
-                // Exact case match (uppercase P/A) → immediate
+                // Exact case match → immediate
                 resolve(opt.action);
                 return;
               }
@@ -599,34 +763,50 @@ export default function (pi: ExtensionAPI) {
   async function promptDomainBlock(
     ctx: ExtensionContext,
     domain: string,
-  ): Promise<"abort" | "session" | "project" | "global"> {
+  ): Promise<"abort" | "once" | "session" | "project" | "global"> {
     return showPermissionPrompt(
       ctx,
       `🌐 Network blocked: "${domain}" is not in allowedDomains`,
       PERMISSION_OPTIONS,
-    );
+    ) as Promise<"abort" | "once" | "session" | "project" | "global">;
   }
 
   async function promptReadBlock(
     ctx: ExtensionContext,
     filePath: string,
-  ): Promise<"abort" | "session" | "project" | "global"> {
+  ): Promise<"abort" | "once" | "session" | "project" | "global"> {
     return showPermissionPrompt(
       ctx,
       `📖 Read blocked: "${filePath}" is not in allowRead`,
       PERMISSION_OPTIONS,
-    );
+    ) as Promise<"abort" | "once" | "session" | "project" | "global">;
   }
 
   async function promptWriteBlock(
     ctx: ExtensionContext,
     filePath: string,
-  ): Promise<"abort" | "session" | "project" | "global"> {
+  ): Promise<"abort" | "once" | "session" | "project" | "global"> {
     return showPermissionPrompt(
       ctx,
       `📝 Write blocked: "${filePath}" is not in allowWrite`,
       PERMISSION_OPTIONS,
-    );
+    ) as Promise<"abort" | "once" | "session" | "project" | "global">;
+  }
+
+  async function promptBypassBlock(
+    ctx: ExtensionContext,
+    command: string,
+    errorOutput: string,
+  ): Promise<"abort" | "once" | "session" | "project" | "global"> {
+    const fullCmd = command.trimStart();
+    const shortCmd = fullCmd.split(/\s+/).slice(0, 3).join(" ");
+    const title =
+      `🔓 Sandbox blocked "${shortCmd}${fullCmd.length > shortCmd.length ? "…" : ""}"\n` +
+      `Error: ${truncateToWidth(errorOutput, 120)}\n` +
+      `Retry unsandboxed?`;
+    return showPermissionPrompt(ctx, title, BYPASS_OPTIONS) as Promise<
+      "abort" | "once" | "session" | "project" | "global"
+    >;
   }
 
   function warnIfAllDomainsAllowed(ctx: ExtensionContext, config: SandboxConfig): void {
@@ -641,89 +821,253 @@ export default function (pi: ExtensionAPI) {
   // ── Apply allowance choices ─────────────────────────────────────────────────
 
   async function applyDomainChoice(
-    choice: "session" | "project" | "global",
+    choice: "once" | "session" | "project" | "global",
     domain: string,
     cwd: string,
   ): Promise<void> {
     const { globalPath, projectPath } = getConfigPaths(cwd);
-    if (!sessionAllowedDomains.includes(domain)) sessionAllowedDomains.push(domain);
+    if (choice !== "once" && !sessionAllowedDomains.includes(domain))
+      sessionAllowedDomains.push(domain);
     if (choice === "project") addDomainToConfig(projectPath, domain);
     if (choice === "global") addDomainToConfig(globalPath, domain);
+    if (choice === "once") sessionAllowedDomains.push(domain);
     await reinitializeSandbox(cwd);
+    if (choice === "once") sessionAllowedDomains.pop();
   }
 
   async function applyReadChoice(
-    choice: "session" | "project" | "global",
+    choice: "once" | "session" | "project" | "global",
     filePath: string,
     cwd: string,
   ): Promise<void> {
     const { globalPath, projectPath } = getConfigPaths(cwd);
-    if (!sessionAllowedReadPaths.includes(filePath)) sessionAllowedReadPaths.push(filePath);
+    if (choice !== "once" && !sessionAllowedReadPaths.includes(filePath))
+      sessionAllowedReadPaths.push(filePath);
     if (choice === "project") addReadPathToConfig(projectPath, filePath);
     if (choice === "global") addReadPathToConfig(globalPath, filePath);
+    if (choice === "once") sessionAllowedReadPaths.push(filePath);
     await reinitializeSandbox(cwd);
+    if (choice === "once") sessionAllowedReadPaths.pop();
   }
 
   async function applyWriteChoice(
-    choice: "session" | "project" | "global",
+    choice: "once" | "session" | "project" | "global",
     filePath: string,
     cwd: string,
   ): Promise<void> {
     const { globalPath, projectPath } = getConfigPaths(cwd);
-    if (!sessionAllowedWritePaths.includes(filePath)) sessionAllowedWritePaths.push(filePath);
+    if (choice !== "once" && !sessionAllowedWritePaths.includes(filePath))
+      sessionAllowedWritePaths.push(filePath);
     if (choice === "project") addWritePathToConfig(projectPath, filePath);
     if (choice === "global") addWritePathToConfig(globalPath, filePath);
+    if (choice === "once") sessionAllowedWritePaths.push(filePath);
     await reinitializeSandbox(cwd);
+    if (choice === "once") sessionAllowedWritePaths.pop();
   }
 
-  // ── Bash tool — with write-block detection and retry ───────────────────────
+  /**
+   * Extract a concise error snippet from command output for the bypass prompt.
+   */
+  function extractErrorSnippet(output: string, maxLen = 80): string {
+    const firstLine = output.split(/\r?\n/)[0]?.trim() ?? "";
+    if (firstLine.length <= maxLen) return firstLine;
+    return firstLine.slice(0, maxLen) + "…";
+  }
+
+  // ── Bash tool — reactive bypass, write-block detection and retry ───────────
 
   pi.registerTool({
     ...localBash,
     label: "bash (sandboxed)",
     async execute(id, params, signal, onUpdate, ctx) {
-      const runBash = () => {
-        if (!sandboxEnabled || !sandboxInitialized) {
-          return localBash.execute(id, params, signal, onUpdate);
-        }
+      const command = (params as { command?: string }).command ?? "";
+
+      const runSandboxed = () => {
         const sandboxedBash = createBashTool(localCwd, {
           operations: createSandboxedBashOps(),
         });
         return sandboxedBash.execute(id, params, signal, onUpdate);
       };
 
-      let result: AgentToolResult<any>;
-      try {
-        result = await runBash();
-      } catch (e) {
-        if (!(e instanceof Error)) throw e;
-        if (!e.message.includes("Operation not permitted")) throw e;
+      const runUnsandboxed = () => localBash.execute(id, params, signal, onUpdate);
 
-        result = {
-          content: [
-            {
-              type: "text",
-              text: `Error: Command failed with OS-level sandbox restriction: ${e.message}`,
-            },
-          ],
-          details: {},
-        };
+      // Check user-configured unsandboxed patterns first
+      const unsandboxedPatterns = getEffectiveUnsandboxedCommands(ctx.cwd);
+      let wasSandboxed = false;
+      let result: AgentToolResult<any>;
+      if (
+        sandboxEnabled &&
+        sandboxInitialized &&
+        commandIsUnsandboxed(command, unsandboxedPatterns)
+      ) {
+        const displayCmd =
+          command.trimStart().length > 80
+            ? command.trimStart().slice(0, 80) + "…"
+            : command.trimStart();
+        const level = getUnsandboxedCommandLevel(command, ctx.cwd, sessionUnsandboxedCommands);
+        ctx.ui.notify(`🔓 Sandbox bypassed for "${displayCmd}" (${level})`, "warning");
+        auditLog({
+          timestamp: new Date().toISOString(),
+          command: command.trimStart().split(/\s+/).join(" "),
+          type: "predictive",
+          choice: level,
+          unsandboxed: true,
+        });
+        pi.sendMessage(
+          {
+            customType: "sandbox-bypass",
+            content: `User allowed unsandboxed execution of "${displayCmd}" (${level} bypass)`,
+            display: false,
+          },
+          {
+            deliverAs: "steer",
+            triggerTurn: false,
+          },
+        );
+        result = await runUnsandboxed();
+      } else if (!sandboxEnabled || !sandboxInitialized) {
+        result = await runUnsandboxed();
+      } else {
+        wasSandboxed = true;
+        try {
+          result = await runSandboxed();
+        } catch (e) {
+          if (!(e instanceof Error)) throw e;
+          result = {
+            content: [
+              {
+                type: "text",
+                text: `Error: Command failed: ${e.message}`,
+              },
+            ],
+            details: { exitCode: 1 },
+          };
+        }
       }
 
-      // Post-execution: detect OS-level write block and offer to allow.
-      if (sandboxEnabled && sandboxInitialized && ctx?.hasUI) {
+      // Check for sandbox failure and offer bypass (only if we actually sandboxed)
+      if (wasSandboxed && sandboxEnabled && sandboxInitialized && ctx?.hasUI) {
         const outputText = result.content
           .filter((c: any) => c.type === "text")
           .map((c: any) => c.text)
           .join("\n");
+        const exitCode = (result.details as any)?.exitCode ?? 0;
+        const failurePatterns =
+          loadConfig(ctx.cwd).sandboxFailurePatterns ?? DEFAULT_FAILURE_PATTERNS;
+        if (isSandboxFailure(outputText, failurePatterns) && exitCode !== 0) {
+          const choice = await promptBypassBlock(ctx, command, extractErrorSnippet(outputText));
 
+          if (choice === "abort") {
+            const displayCmd =
+              command.trimStart().length > 80
+                ? command.trimStart().slice(0, 80) + "…"
+                : command.trimStart();
+            ctx.ui.notify(`🛡️  Sandbox bypass declined for "${displayCmd}"`, "info");
+            pi.sendMessage(
+              {
+                customType: "sandbox-bypass",
+                content: `User declined unsandboxed execution of "${displayCmd}" (kept sandboxed failure)`,
+                display: false,
+              },
+              {
+                deliverAs: "steer",
+                triggerTurn: false,
+              },
+            );
+            auditLog({
+              timestamp: new Date().toISOString(),
+              command: command.trimStart().split(/\s+/).join(" "),
+              type: "reactive",
+              choice: "declined",
+              unsandboxed: false,
+            });
+          } else {
+            const displayCmd =
+              command.trimStart().length > 80
+                ? command.trimStart().slice(0, 80) + "…"
+                : command.trimStart();
+            const normalized = command.trimStart().split(/\s+/).join(" ");
+
+            if (choice === "session") {
+              if (normalized && !sessionUnsandboxedCommands.includes(normalized)) {
+                sessionUnsandboxedCommands.push(normalized);
+              }
+            } else if (choice === "project") {
+              addUnsandboxedCommandToConfig(getConfigPaths(ctx.cwd).projectPath, command);
+            } else if (choice === "global") {
+              addUnsandboxedCommandToConfig(getConfigPaths(ctx.cwd).globalPath, command);
+            }
+
+            const bypassLabel =
+              choice === "once"
+                ? "once"
+                : choice === "session"
+                  ? "session"
+                  : choice === "project"
+                    ? "project"
+                    : "global";
+
+            ctx.ui.notify(`🔓 Sandbox bypassed for "${displayCmd}" (${bypassLabel})`, "warning");
+
+            pi.sendMessage(
+              {
+                customType: "sandbox-bypass",
+                content: `User allowed unsandboxed execution of "${displayCmd}" (${bypassLabel} bypass after sandbox failure)`,
+                display: false,
+              },
+              {
+                deliverAs: "steer",
+                triggerTurn: false,
+              },
+            );
+            auditLog({
+              timestamp: new Date().toISOString(),
+              command: normalized,
+              type: "reactive",
+              choice: choice,
+              unsandboxed: true,
+            });
+
+            onUpdate?.({
+              content: [{ type: "text", text: `\n--- Retrying unsandboxed ---\n` }],
+              details: {},
+            });
+
+            result = await runUnsandboxed();
+          }
+        }
+
+        // Also check for OS-level write block (separate from sandbox failure)
         const blockedPath = extractBlockedWritePath(outputText);
         if (blockedPath) {
           const choice = await promptWriteBlock(ctx, blockedPath);
           if (choice !== "abort") {
             await applyWriteChoice(choice, blockedPath, ctx.cwd);
+            const level =
+              choice === "once"
+                ? "once"
+                : choice === "session"
+                  ? "session"
+                  : choice === "project"
+                    ? "project"
+                    : "global";
+            ctx.ui.notify(`📝 Write path "${blockedPath}" allowed (${level})`, "info");
+            pi.sendMessage(
+              {
+                customType: "sandbox-permission",
+                content: `User allowed write path "${blockedPath}" (${level})`,
+                display: false,
+              },
+              { deliverAs: "steer", triggerTurn: false },
+            );
+            auditLog({
+              timestamp: new Date().toISOString(),
+              command: blockedPath,
+              type: "predictive",
+              choice: level,
+              unsandboxed: false,
+            });
 
-            // Check if denyWrite would still block it even after allowing.
             const config = loadConfig(ctx.cwd);
             const { projectPath, globalPath } = getConfigPaths(ctx.cwd);
             if (matchesPattern(blockedPath, config.filesystem?.denyWrite ?? [])) {
@@ -744,7 +1088,7 @@ export default function (pi: ExtensionAPI) {
               ],
               details: {},
             });
-            return runBash();
+            result = await runSandboxed();
           }
         }
       }
@@ -753,14 +1097,14 @@ export default function (pi: ExtensionAPI) {
     },
   });
 
-  // ── user_bash — network pre-check ──────────────────────────────────────────
+  // ── user_bash — network pre-check + reactive bypass ───────────────────────
 
   pi.on("user_bash", async (event, ctx) => {
     if (!sandboxEnabled || !sandboxInitialized) return;
 
+    // Network pre-check
     const domains = extractDomainsFromCommand(event.command);
     const effectiveDomains = getEffectiveAllowedDomains(ctx.cwd);
-
     for (const domain of domains) {
       if (!domainIsAllowed(domain, effectiveDomains)) {
         const choice = await promptDomainBlock(ctx, domain);
@@ -775,10 +1119,185 @@ export default function (pi: ExtensionAPI) {
           };
         }
         await applyDomainChoice(choice, domain, ctx.cwd);
+        const level =
+          choice === "once"
+            ? "once"
+            : choice === "session"
+              ? "session"
+              : choice === "project"
+                ? "project"
+                : "global";
+        ctx.ui.notify(`🌐 Domain "${domain}" allowed (${level})`, "info");
+        pi.sendMessage(
+          {
+            customType: "sandbox-permission",
+            content: `User allowed domain "${domain}" (${level})`,
+            display: false,
+          },
+          { deliverAs: "steer", triggerTurn: false },
+        );
+        auditLog({
+          timestamp: new Date().toISOString(),
+          command: domain,
+          type: "predictive",
+          choice: level,
+          unsandboxed: false,
+        });
       }
     }
 
-    return { operations: createSandboxedBashOps() };
+    // Predictive bypass: user-configured unsandboxed commands
+    const unsandboxedPatterns = getEffectiveUnsandboxedCommands(ctx.cwd);
+    if (commandIsUnsandboxed(event.command, unsandboxedPatterns)) {
+      const displayCmd =
+        event.command.trimStart().length > 80
+          ? event.command.trimStart().slice(0, 80) + "…"
+          : event.command.trimStart();
+      const level = getUnsandboxedCommandLevel(event.command, ctx.cwd, sessionUnsandboxedCommands);
+      ctx.ui.notify(`🔓 Sandbox bypassed for "${displayCmd}" (${level})`, "warning");
+      auditLog({
+        timestamp: new Date().toISOString(),
+        command: event.command.trimStart().split(/\s+/).join(" "),
+        type: "predictive",
+        choice: level,
+        unsandboxed: true,
+      });
+      pi.sendMessage(
+        {
+          customType: "sandbox-bypass",
+          content: `User allowed unsandboxed execution of "${displayCmd}" (${level} bypass)`,
+          display: false,
+        },
+        {
+          deliverAs: "steer",
+          triggerTurn: false,
+        },
+      );
+      return; // Let default (unsandboxed) bash run
+    }
+
+    // Reactive bypass: run sandboxed first, prompt on failure
+    if (!ctx.hasUI) {
+      return { operations: createSandboxedBashOps() };
+    }
+
+    const sandboxedOps = createSandboxedBashOps();
+    let output = "";
+    let exitCode = 0;
+    let wasSandboxed = true;
+    try {
+      const execResult = await sandboxedOps.exec(event.command, event.cwd, {
+        onData: (chunk) => {
+          output += chunk;
+        },
+      });
+      exitCode = execResult.exitCode ?? 1;
+    } catch (e) {
+      output = e instanceof Error ? e.message : String(e);
+      exitCode = 1;
+    }
+
+    const failurePatterns = loadConfig(ctx.cwd).sandboxFailurePatterns ?? DEFAULT_FAILURE_PATTERNS;
+    if (wasSandboxed && exitCode !== 0 && isSandboxFailure(output, failurePatterns)) {
+      const choice = await promptBypassBlock(ctx, event.command, extractErrorSnippet(output));
+
+      if (choice === "abort") {
+        const displayCmd =
+          event.command.trimStart().length > 80
+            ? event.command.trimStart().slice(0, 80) + "…"
+            : event.command.trimStart();
+        ctx.ui.notify(`🛡️  Sandbox bypass declined for "${displayCmd}"`, "info");
+        pi.sendMessage(
+          {
+            customType: "sandbox-bypass",
+            content: `User declined unsandboxed execution of "${displayCmd}" (kept sandboxed failure)`,
+            display: false,
+          },
+          {
+            deliverAs: "steer",
+            triggerTurn: false,
+          },
+        );
+        auditLog({
+          timestamp: new Date().toISOString(),
+          command: event.command.trimStart().split(/\s+/).join(" "),
+          type: "reactive",
+          choice: "declined",
+          unsandboxed: false,
+        });
+      } else {
+        const normalized = event.command.trimStart().split(/\s+/).join(" ");
+        if (
+          choice === "session" &&
+          normalized &&
+          !sessionUnsandboxedCommands.includes(normalized)
+        ) {
+          sessionUnsandboxedCommands.push(normalized);
+        } else if (choice === "project") {
+          addUnsandboxedCommandToConfig(getConfigPaths(ctx.cwd).projectPath, event.command);
+        } else if (choice === "global") {
+          addUnsandboxedCommandToConfig(getConfigPaths(ctx.cwd).globalPath, event.command);
+        }
+
+        const bypassLabel =
+          choice === "once"
+            ? "once"
+            : choice === "session"
+              ? "session"
+              : choice === "project"
+                ? "project"
+                : "global";
+        const displayCmd =
+          event.command.trimStart().length > 80
+            ? event.command.trimStart().slice(0, 80) + "…"
+            : event.command.trimStart();
+
+        ctx.ui.notify(`🔓 Sandbox bypassed for "${displayCmd}" (${bypassLabel})`, "warning");
+
+        pi.sendMessage(
+          {
+            customType: "sandbox-bypass",
+            content: `User allowed unsandboxed execution of "${displayCmd}" (${bypassLabel} bypass after sandbox failure)`,
+            display: false,
+          },
+          {
+            deliverAs: "steer",
+            triggerTurn: false,
+          },
+        );
+        auditLog({
+          timestamp: new Date().toISOString(),
+          command: normalized,
+          type: "reactive",
+          choice: choice,
+          unsandboxed: true,
+        });
+
+        // Rerun unsandboxed
+        const localOps = createLocalBashOperations();
+        output = "";
+        try {
+          const execResult = await localOps.exec(event.command, event.cwd, {
+            onData: (chunk) => {
+              output += chunk;
+            },
+          });
+          exitCode = execResult.exitCode ?? 1;
+        } catch (e) {
+          output = e instanceof Error ? e.message : String(e);
+          exitCode = 1;
+        }
+      }
+    }
+
+    return {
+      result: {
+        output,
+        exitCode,
+        cancelled: false,
+        truncated: false,
+      },
+    };
   });
 
   // ── tool_call — network pre-check for bash, path policy for read/write/edit
@@ -805,6 +1324,30 @@ export default function (pi: ExtensionAPI) {
             };
           }
           await applyDomainChoice(choice, domain, ctx.cwd);
+          const level =
+            choice === "once"
+              ? "once"
+              : choice === "session"
+                ? "session"
+                : choice === "project"
+                  ? "project"
+                  : "global";
+          ctx.ui.notify(`🌐 Domain "${domain}" allowed (${level})`, "info");
+          pi.sendMessage(
+            {
+              customType: "sandbox-permission",
+              content: `User allowed domain "${domain}" (${level})`,
+              display: false,
+            },
+            { deliverAs: "steer", triggerTurn: false },
+          );
+          auditLog({
+            timestamp: new Date().toISOString(),
+            command: domain,
+            type: "predictive",
+            choice: level,
+            unsandboxed: false,
+          });
         }
       }
     }
@@ -828,6 +1371,30 @@ export default function (pi: ExtensionAPI) {
           };
         }
         await applyReadChoice(choice, filePath, ctx.cwd);
+        const level =
+          choice === "once"
+            ? "once"
+            : choice === "session"
+              ? "session"
+              : choice === "project"
+                ? "project"
+                : "global";
+        ctx.ui.notify(`📖 Read path "${filePath}" allowed (${level})`, "info");
+        pi.sendMessage(
+          {
+            customType: "sandbox-permission",
+            content: `User allowed read path "${filePath}" (${level})`,
+            display: false,
+          },
+          { deliverAs: "steer", triggerTurn: false },
+        );
+        auditLog({
+          timestamp: new Date().toISOString(),
+          command: filePath,
+          type: "predictive",
+          choice: level,
+          unsandboxed: false,
+        });
         // Allowed — fall through, tool runs.
         return;
       }
@@ -848,6 +1415,30 @@ export default function (pi: ExtensionAPI) {
           };
         }
         await applyWriteChoice(choice, path, ctx.cwd);
+        const level =
+          choice === "once"
+            ? "once"
+            : choice === "session"
+              ? "session"
+              : choice === "project"
+                ? "project"
+                : "global";
+        ctx.ui.notify(`📝 Write path "${path}" allowed (${level})`, "info");
+        pi.sendMessage(
+          {
+            customType: "sandbox-permission",
+            content: `User allowed write path "${path}" (${level})`,
+            display: false,
+          },
+          { deliverAs: "steer", triggerTurn: false },
+        );
+        auditLog({
+          timestamp: new Date().toISOString(),
+          command: path,
+          type: "predictive",
+          choice: level,
+          unsandboxed: false,
+        });
 
         // denyWrite takes precedence — warn if it would still block.
         if (matchesPattern(path, denyWrite)) {
@@ -958,6 +1549,10 @@ export default function (pi: ExtensionAPI) {
   // ── session_shutdown ────────────────────────────────────────────────────────
 
   pi.on("session_shutdown", async () => {
+    sessionAllowedDomains.length = 0;
+    sessionAllowedReadPaths.length = 0;
+    sessionAllowedWritePaths.length = 0;
+    sessionUnsandboxedCommands.length = 0;
     if (sandboxInitialized) {
       try {
         await SandboxManager.reset();
@@ -1042,6 +1637,10 @@ export default function (pi: ExtensionAPI) {
         }
       }
 
+      sessionAllowedDomains.length = 0;
+      sessionAllowedReadPaths.length = 0;
+      sessionAllowedWritePaths.length = 0;
+      sessionUnsandboxedCommands.length = 0;
       sandboxEnabled = false;
       sandboxInitialized = false;
       ctx.ui.setStatus("sandbox", "");
@@ -1086,11 +1685,55 @@ export default function (pi: ExtensionAPI) {
         ...(sessionAllowedWritePaths.length > 0
           ? [`  Session write: ${sessionAllowedWritePaths.join(", ")}`]
           : []),
+        ...(sessionUnsandboxedCommands.length > 0
+          ? [`  Session unsandboxed: ${sessionUnsandboxedCommands.join(", ")}`]
+          : []),
+        `  Unsandboxed:   ${config.unsandboxedCommands?.join(", ") || "(none)"}`,
+        `  Failure patterns: ${(config.sandboxFailurePatterns ?? DEFAULT_FAILURE_PATTERNS).join(", ")}`,
+
         "",
         "Note: ALL reads are prompted unless the path is already in allowRead.",
         "Note: denyRead is not a hard-block — granting a prompt adds to allowRead, overriding denyRead.",
         "Note: denyWrite takes PRECEDENCE over allowWrite and is never prompted.",
+        "Note: Reactive bypass detects sandbox/auth failures in output. Add custom patterns via sandboxFailurePatterns config.",
       ];
+      ctx.ui.notify(lines.join("\n"), "info");
+    },
+  });
+
+  pi.registerCommand("sandbox-debug", {
+    description: "Debug sandbox config loading",
+    handler: async (_args, ctx) => {
+      const config = loadConfig(ctx.cwd);
+      const { globalPath, projectPath } = getConfigPaths(ctx.cwd);
+
+      const lines = [
+        "Sandbox Debug",
+        `  cwd: ${ctx.cwd}`,
+        `  projectPath: ${projectPath}`,
+        `  globalPath: ${globalPath}`,
+        `  project exists: ${existsSync(projectPath)}`,
+        `  global exists: ${existsSync(globalPath)}`,
+        "",
+        "Loaded config:",
+        `  enabled: ${config.enabled}`,
+        `  unsandboxedCommands: ${JSON.stringify(config.unsandboxedCommands)}`,
+        `  sandboxFailurePatterns: ${JSON.stringify(config.sandboxFailurePatterns)}`,
+        "",
+        "Session state:",
+        `  sessionUnsandboxedCommands: ${JSON.stringify(sessionUnsandboxedCommands)}`,
+        "",
+        "Test match:",
+      ];
+
+      const testCmd = 'security find-generic-password -s "test" 2>&1 | head -3';
+      const normalized = testCmd.trimStart().split(/\s+/).join(" ");
+      const patterns = getEffectiveUnsandboxedCommands(ctx.cwd);
+      lines.push(`  test command: ${testCmd}`);
+      lines.push(`  normalized: ${normalized}`);
+      lines.push(`  patterns: ${JSON.stringify(patterns)}`);
+      lines.push(`  match: ${commandIsUnsandboxed(testCmd, patterns)}`);
+
       ctx.ui.notify(lines.join("\n"), "info");
     },
   });

--- a/index.ts
+++ b/index.ts
@@ -1037,11 +1037,6 @@ export default function (pi: ExtensionAPI) {
               unsandboxed: true,
             });
 
-            onUpdate?.({
-              content: [{ type: "text", text: `\n--- Retrying unsandboxed ---\n` }],
-              details: {},
-            });
-
             result = await runUnsandboxed();
             bypassAccepted = true;
           }

--- a/index.ts
+++ b/index.ts
@@ -1494,14 +1494,22 @@ export default function (pi: ExtensionAPI) {
           sessionAllowedWritePaths?: string[];
           sessionUnsandboxedCommands?: string[];
         };
-        if (data.sessionAllowedDomains) sessionAllowedDomains.push(...data.sessionAllowedDomains);
-        if (data.sessionAllowedReadPaths)
+        if (data.sessionAllowedDomains) {
+          sessionAllowedDomains.length = 0;
+          sessionAllowedDomains.push(...data.sessionAllowedDomains);
+        }
+        if (data.sessionAllowedReadPaths) {
+          sessionAllowedReadPaths.length = 0;
           sessionAllowedReadPaths.push(...data.sessionAllowedReadPaths);
-        if (data.sessionAllowedWritePaths)
+        }
+        if (data.sessionAllowedWritePaths) {
+          sessionAllowedWritePaths.length = 0;
           sessionAllowedWritePaths.push(...data.sessionAllowedWritePaths);
-        if (data.sessionUnsandboxedCommands)
+        }
+        if (data.sessionUnsandboxedCommands) {
+          sessionUnsandboxedCommands.length = 0;
           sessionUnsandboxedCommands.push(...data.sessionUnsandboxedCommands);
-        break; // Only read the most recent entry
+        }
       }
     }
 

--- a/index.ts
+++ b/index.ts
@@ -894,7 +894,7 @@ export default function (pi: ExtensionAPI) {
         return sandboxedBash.execute(id, params, signal, onUpdate);
       };
 
-      const runUnsandboxed = () => localBash.execute(id + "-retry", params, signal, onUpdate);
+      const runUnsandboxed = () => localBash.execute(id, params, signal, onUpdate);
 
       // Check user-configured unsandboxed patterns first
       const unsandboxedPatterns = getEffectiveUnsandboxedCommands(ctx.cwd);

--- a/index.ts
+++ b/index.ts
@@ -886,7 +886,6 @@ export default function (pi: ExtensionAPI) {
     label: "bash (sandboxed)",
     async execute(id, params, signal, onUpdate, ctx) {
       const command = (params as { command?: string }).command ?? "";
-      ctx.ui.notify(`NOTIFY TEST: ${command.slice(0, 40)}`, "info");
 
       const runSandboxed = () => {
         const sandboxedBash = createBashTool(localCwd, {

--- a/index.ts
+++ b/index.ts
@@ -152,6 +152,7 @@ function auditLog(entry: {
 
 /**
  * Determine the config level for an unsandboxed command.
+ * Determine the config level for an unsandboxed command.
  * Returns "project-config", "global-config", or "session" based on which config
  * contains the command. "-config" suffix means no user interaction occurred.
  */
@@ -624,6 +625,70 @@ export default function (pi: ExtensionAPI) {
   // ── UI prompts ──────────────────────────────────────────────────────────────
 
   type Action = "abort" | "session" | "project" | "global" | "once" | "project-config" | "global-config";
+
+  // ── Record decision + notify user + agent ───────────────────────────────────
+
+  function recordDecisionAndNotify(
+    ctx: ExtensionContext,
+    decision: {
+      action: "bypass-predictive" | "bypass-retry" | "bypass-declined" | "domain-allowed" | "read-allowed" | "write-allowed";
+      target: string;
+      choice: string;
+    },
+  ): void {
+    const { action, target, choice } = decision;
+
+    const auditType: "predictive" | "reactive" =
+      action === "bypass-predictive" ? "predictive" : "reactive";
+    const unsandboxed =
+      action === "bypass-predictive" || action === "bypass-retry";
+
+    auditLog({
+      timestamp: new Date().toISOString(),
+      command: target,
+      type: auditType,
+      choice: choice as any,
+      unsandboxed,
+    });
+
+    let notifyMsg: string;
+    let sendMsg: string;
+    let level: "info" | "warning" = "info";
+
+    switch (action) {
+      case "bypass-predictive":
+        notifyMsg = `🔓 Sandbox disabled: "${target}" (${choice})`;
+        sendMsg = `User pre-configured unsandboxed execution of exact command "${target}" (${choice})`;
+        level = "warning";
+        break;
+      case "bypass-retry":
+        notifyMsg = `🔓 Retried without sandbox: "${target}" (exact match, ${choice})`;
+        sendMsg = `User retried "${target}" without sandbox (exact match, ${choice})`;
+        break;
+      case "bypass-declined":
+        notifyMsg = `🛡️  Kept sandboxed: "${target}"`;
+        sendMsg = `User declined unsandboxed retry of "${target}"`;
+        break;
+      case "domain-allowed":
+        notifyMsg = `🌐 Domain "${target}" allowed (${choice})`;
+        sendMsg = `User allowed domain "${target}" (${choice})`;
+        break;
+      case "read-allowed":
+        notifyMsg = `📖 Read path "${target}" allowed (${choice})`;
+        sendMsg = `User allowed read path "${target}" (${choice})`;
+        break;
+      case "write-allowed":
+        notifyMsg = `📝 Write path "${target}" allowed (${choice})`;
+        sendMsg = `User allowed write path "${target}" (${choice})`;
+        break;
+    }
+
+    ctx.ui.notify(notifyMsg, level);
+    pi.sendMessage(
+      { customType: "sandbox-decision", content: sendMsg, display: false },
+      { deliverAs: "steer", triggerTurn: false },
+    );
+  }
 
   interface PromptOption {
     label: string;

--- a/index.ts
+++ b/index.ts
@@ -906,7 +906,7 @@ export default function (pi: ExtensionAPI) {
             ? command.trimStart().slice(0, 80) + "…"
             : command.trimStart();
         const level = getUnsandboxedCommandLevel(command, ctx.cwd, sessionUnsandboxedCommands);
-        ctx.ui.notify(`🔓 Sandbox bypassed for "${displayCmd}" (${level})`, "warning");
+        ctx.ui.notify(`🔓 Sandbox disabled: "${displayCmd}" (${level} config)`, "warning");
         auditLog({
           timestamp: new Date().toISOString(),
           command: command.trimStart().split(/\s+/).join(" "),
@@ -917,7 +917,7 @@ export default function (pi: ExtensionAPI) {
         pi.sendMessage(
           {
             customType: "sandbox-bypass",
-            content: `User allowed unsandboxed execution of "${displayCmd}" (${level} bypass)`,
+            content: `User pre-configured unsandboxed execution of exact command "${displayCmd}" (${level})`,
             display: false,
           },
           {
@@ -963,11 +963,11 @@ export default function (pi: ExtensionAPI) {
               command.trimStart().length > 80
                 ? command.trimStart().slice(0, 80) + "…"
                 : command.trimStart();
-            ctx.ui.notify(`🛡️  Sandbox bypass declined for "${displayCmd}"`, "info");
+            ctx.ui.notify(`🛡️  Kept sandboxed: "${displayCmd}"`, "info");
             pi.sendMessage(
               {
                 customType: "sandbox-bypass",
-                content: `User declined unsandboxed execution of "${displayCmd}" (kept sandboxed failure)`,
+                content: `User declined unsandboxed retry of "${displayCmd}"`,
                 display: false,
               },
               {
@@ -1008,12 +1008,15 @@ export default function (pi: ExtensionAPI) {
                     ? "project"
                     : "global";
 
-            ctx.ui.notify(`🔓 Sandbox bypassed for "${displayCmd}" (${bypassLabel})`, "warning");
+            ctx.ui.notify(
+              `🔓 Retried without sandbox: "${displayCmd}" (exact match, ${bypassLabel})`,
+              "warning",
+            );
 
             pi.sendMessage(
               {
                 customType: "sandbox-bypass",
-                content: `User allowed unsandboxed execution of "${displayCmd}" (${bypassLabel} bypass after sandbox failure)`,
+                content: `User retried "${displayCmd}" without sandbox (exact match, ${bypassLabel})`,
                 display: false,
               },
               {
@@ -1155,7 +1158,7 @@ export default function (pi: ExtensionAPI) {
           ? event.command.trimStart().slice(0, 80) + "…"
           : event.command.trimStart();
       const level = getUnsandboxedCommandLevel(event.command, ctx.cwd, sessionUnsandboxedCommands);
-      ctx.ui.notify(`🔓 Sandbox bypassed for "${displayCmd}" (${level})`, "warning");
+      ctx.ui.notify(`🔓 Sandbox disabled: "${displayCmd}" (${level} config)`, "warning");
       auditLog({
         timestamp: new Date().toISOString(),
         command: event.command.trimStart().split(/\s+/).join(" "),
@@ -1166,7 +1169,7 @@ export default function (pi: ExtensionAPI) {
       pi.sendMessage(
         {
           customType: "sandbox-bypass",
-          content: `User allowed unsandboxed execution of "${displayCmd}" (${level} bypass)`,
+          content: `User pre-configured unsandboxed execution of exact command "${displayCmd}" (${level})`,
           display: false,
         },
         {
@@ -1207,11 +1210,11 @@ export default function (pi: ExtensionAPI) {
           event.command.trimStart().length > 80
             ? event.command.trimStart().slice(0, 80) + "…"
             : event.command.trimStart();
-        ctx.ui.notify(`🛡️  Sandbox bypass declined for "${displayCmd}"`, "info");
+        ctx.ui.notify(`🛡️  Kept sandboxed: "${displayCmd}"`, "info");
         pi.sendMessage(
           {
             customType: "sandbox-bypass",
-            content: `User declined unsandboxed execution of "${displayCmd}" (kept sandboxed failure)`,
+            content: `User declined unsandboxed retry of "${displayCmd}"`,
             display: false,
           },
           {
@@ -1253,12 +1256,15 @@ export default function (pi: ExtensionAPI) {
             ? event.command.trimStart().slice(0, 80) + "…"
             : event.command.trimStart();
 
-        ctx.ui.notify(`🔓 Sandbox bypassed for "${displayCmd}" (${bypassLabel})`, "warning");
+        ctx.ui.notify(
+          `🔓 Retried without sandbox: "${displayCmd}" (exact match, ${bypassLabel})`,
+          "warning",
+        );
 
         pi.sendMessage(
           {
             customType: "sandbox-bypass",
-            content: `User allowed unsandboxed execution of "${displayCmd}" (${bypassLabel} bypass after sandbox failure)`,
+            content: `User retried "${displayCmd}" without sandbox (exact match, ${bypassLabel})`,
             display: false,
           },
           {

--- a/index.ts
+++ b/index.ts
@@ -957,6 +957,7 @@ export default function (pi: ExtensionAPI) {
           .map((c: any) => c.text)
           .join("\n");
         const exitCode = (result.details as any)?.exitCode ?? 0;
+        let bypassAccepted = false;
         const failurePatterns =
           loadConfig(ctx.cwd).sandboxFailurePatterns ?? DEFAULT_FAILURE_PATTERNS;
         if (isSandboxFailure(outputText, failurePatterns) && exitCode !== 0) {
@@ -1042,12 +1043,14 @@ export default function (pi: ExtensionAPI) {
             });
 
             result = await runUnsandboxed();
+            bypassAccepted = true;
           }
         }
 
         // Also check for OS-level write block (separate from sandbox failure)
+        // Skip if bypass was accepted — the unsandboxed retry already handled the write.
         const blockedPath = extractBlockedWritePath(outputText);
-        if (blockedPath) {
+        if (blockedPath && !bypassAccepted) {
           const choice = await promptWriteBlock(ctx, blockedPath);
           if (choice !== "abort") {
             await applyWriteChoice(choice, blockedPath, ctx.cwd);

--- a/index.ts
+++ b/index.ts
@@ -894,7 +894,7 @@ export default function (pi: ExtensionAPI) {
         return sandboxedBash.execute(id, params, signal, onUpdate);
       };
 
-      const runUnsandboxed = () => localBash.execute(id, params, signal, onUpdate);
+      const runUnsandboxed = () => localBash.execute(id + "-retry", params, signal, onUpdate);
 
       // Check user-configured unsandboxed patterns first
       const unsandboxedPatterns = getEffectiveUnsandboxedCommands(ctx.cwd);

--- a/index.ts
+++ b/index.ts
@@ -703,10 +703,9 @@ export default function (pi: ExtensionAPI) {
           },
 
           handleInput(data: string): void {
-            // Passthrough: let pi handle app-level keys (Ctrl+O expand, etc.)
-            if (matchesKey(data, Key.ctrl("o")) || matchesKey(data, Key.ctrl("p"))) {
-              return;
-            }
+            // NOTE: pi routes ALL keyboard input to this component when focused.
+            // App-level keys like Ctrl+O (expand) are NOT processed. Workaround:
+            // esc to dismiss, expand tool output, then re-trigger the prompt.
 
             if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
               resolve("abort");

--- a/index.ts
+++ b/index.ts
@@ -659,6 +659,8 @@ export default function (pi: ExtensionAPI) {
       (tui, theme, _kb, done) => {
         let selectedIndex = 0;
         let pendingAction: "abort" | "session" | "project" | "global" | "once" | null = null;
+        let renderedAt = 0;
+        const DEBOUNCE_MS = 400;
 
         function resolve(action: "abort" | "session" | "project" | "global" | "once") {
           done(action);
@@ -666,6 +668,7 @@ export default function (pi: ExtensionAPI) {
 
         return {
           render(width: number): string[] {
+            if (renderedAt === 0) renderedAt = Date.now();
             const lines: string[] = [];
             lines.push(truncateToWidth(theme.fg("warning", title), width));
             lines.push("");
@@ -706,6 +709,20 @@ export default function (pi: ExtensionAPI) {
             // NOTE: pi routes ALL keyboard input to this component when focused.
             // App-level keys like Ctrl+O (expand) are NOT processed. Workaround:
             // esc to dismiss, expand tool output, then re-trigger the prompt.
+
+            // Debounce: ignore single-key presses for DEBOUNCE_MS after prompt appears.
+            // Prevents accidental selection when user is typing in chat text box.
+            // Navigation keys (arrows, enter, escape) are always allowed.
+            if (
+              Date.now() - renderedAt < DEBOUNCE_MS &&
+              !matchesKey(data, Key.enter) &&
+              !matchesKey(data, Key.escape) &&
+              !matchesKey(data, Key.ctrl("c")) &&
+              !matchesKey(data, Key.up) &&
+              !matchesKey(data, Key.down)
+            ) {
+              return;
+            }
 
             if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
               resolve("abort");

--- a/index.ts
+++ b/index.ts
@@ -313,7 +313,7 @@ function createNetworkAskCallback(allowedDomains: string[]): SandboxAskCallback 
 
 /**
  * Default patterns that indicate a sandbox/auth/keychain failure.
- * Users can override/extend these in their sandbox.json config.
+ * Override via "sandboxFailurePatterns" key in sandbox.json.
  */
 const DEFAULT_FAILURE_PATTERNS: string[] = [
   "operation not permitted",
@@ -608,10 +608,12 @@ export default function (pi: ExtensionAPI) {
 
   // ── UI prompts ──────────────────────────────────────────────────────────────
 
+  type Action = "abort" | "session" | "project" | "global" | "once" | "project-config" | "global-config";
+
   interface PromptOption {
     label: string;
     key: string;
-    action: "abort" | "session" | "project" | "global" | "once";
+    action: Action;
     confirm?: boolean;
     hint?: string;
   }
@@ -656,21 +658,32 @@ export default function (pi: ExtensionAPI) {
     },
   ];
 
+  /** True if the key event is a navigation key (arrows, enter, escape). */
+  function isNavigationKey(data: string): boolean {
+    return (
+      matchesKey(data, Key.enter) ||
+      matchesKey(data, Key.escape) ||
+      matchesKey(data, Key.ctrl("c")) ||
+      matchesKey(data, Key.up) ||
+      matchesKey(data, Key.down)
+    );
+  }
+
   async function showPermissionPrompt(
     ctx: ExtensionContext,
     title: string,
     options: PromptOption[],
-  ): Promise<"abort" | "session" | "project" | "global" | "once"> {
+  ): Promise<Action> {
     if (!ctx.hasUI) return "abort";
 
-    const result = await ctx.ui.custom<"abort" | "session" | "project" | "global" | "once">(
+    const result = await ctx.ui.custom<Action>(
       (tui, theme, _kb, done) => {
         let selectedIndex = 0;
-        let pendingAction: "abort" | "session" | "project" | "global" | "once" | null = null;
+        let pendingAction: Action | null = null;
         let renderedAt = 0;
         const DEBOUNCE_MS = 400;
 
-        function resolve(action: "abort" | "session" | "project" | "global" | "once") {
+        function resolve(action: Action) {
           done(action);
         }
 
@@ -721,14 +734,7 @@ export default function (pi: ExtensionAPI) {
             // Debounce: ignore single-key presses for DEBOUNCE_MS after prompt appears.
             // Prevents accidental selection when user is typing in chat text box.
             // Navigation keys (arrows, enter, escape) are always allowed.
-            if (
-              Date.now() - renderedAt < DEBOUNCE_MS &&
-              !matchesKey(data, Key.enter) &&
-              !matchesKey(data, Key.escape) &&
-              !matchesKey(data, Key.ctrl("c")) &&
-              !matchesKey(data, Key.up) &&
-              !matchesKey(data, Key.down)
-            ) {
+            if (Date.now() - renderedAt < DEBOUNCE_MS && !isNavigationKey(data)) {
               return;
             }
 
@@ -793,50 +799,48 @@ export default function (pi: ExtensionAPI) {
   async function promptDomainBlock(
     ctx: ExtensionContext,
     domain: string,
-  ): Promise<"abort" | "once" | "session" | "project" | "global"> {
+  ): Promise<Action> {
     return showPermissionPrompt(
       ctx,
       `🌐 Network blocked: "${domain}" is not in allowedDomains`,
       PERMISSION_OPTIONS,
-    ) as Promise<"abort" | "once" | "session" | "project" | "global">;
+    ) as Promise<Action>;
   }
 
   async function promptReadBlock(
     ctx: ExtensionContext,
     filePath: string,
-  ): Promise<"abort" | "once" | "session" | "project" | "global"> {
+  ): Promise<Action> {
     return showPermissionPrompt(
       ctx,
       `📖 Read blocked: "${filePath}" is not in allowRead`,
       PERMISSION_OPTIONS,
-    ) as Promise<"abort" | "once" | "session" | "project" | "global">;
+    ) as Promise<Action>;
   }
 
   async function promptWriteBlock(
     ctx: ExtensionContext,
     filePath: string,
-  ): Promise<"abort" | "once" | "session" | "project" | "global"> {
+  ): Promise<Action> {
     return showPermissionPrompt(
       ctx,
       `📝 Write blocked: "${filePath}" is not in allowWrite`,
       PERMISSION_OPTIONS,
-    ) as Promise<"abort" | "once" | "session" | "project" | "global">;
+    ) as Promise<Action>;
   }
 
   async function promptBypassBlock(
     ctx: ExtensionContext,
     command: string,
     errorOutput: string,
-  ): Promise<"abort" | "once" | "session" | "project" | "global"> {
+  ): Promise<Action> {
     const fullCmd = command.trimStart();
     const shortCmd = fullCmd.split(/\s+/).slice(0, 3).join(" ");
     const title =
       `🔓 Sandbox blocked "${shortCmd}${fullCmd.length > shortCmd.length ? "…" : ""}"\n` +
       `Error: ${truncateToWidth(errorOutput, 120)}\n` +
       `Retry unsandboxed?`;
-    return showPermissionPrompt(ctx, title, BYPASS_OPTIONS) as Promise<
-      "abort" | "once" | "session" | "project" | "global"
-    >;
+    return showPermissionPrompt(ctx, title, BYPASS_OPTIONS) as Promise<Action>;
   }
 
   function warnIfAllDomainsAllowed(ctx: ExtensionContext, config: SandboxConfig): void {
@@ -851,7 +855,7 @@ export default function (pi: ExtensionAPI) {
   // ── Apply allowance choices ─────────────────────────────────────────────────
 
   async function applyDomainChoice(
-    choice: "once" | "session" | "project" | "global",
+    choice: Action,
     domain: string,
     cwd: string,
   ): Promise<void> {
@@ -866,7 +870,7 @@ export default function (pi: ExtensionAPI) {
   }
 
   async function applyReadChoice(
-    choice: "once" | "session" | "project" | "global",
+    choice: Action,
     filePath: string,
     cwd: string,
   ): Promise<void> {
@@ -881,7 +885,7 @@ export default function (pi: ExtensionAPI) {
   }
 
   async function applyWriteChoice(
-    choice: "once" | "session" | "project" | "global",
+    choice: Action,
     filePath: string,
     cwd: string,
   ): Promise<void> {
@@ -893,6 +897,13 @@ export default function (pi: ExtensionAPI) {
     if (choice === "once") sessionAllowedWritePaths.push(filePath);
     await reinitializeSandbox(cwd);
     if (choice === "once") sessionAllowedWritePaths.pop();
+  }
+
+  /** Truncate a command string for display, keeping maxLen chars. */
+  function truncateCmd(cmd: string, maxLen = 80): string {
+    const trimmed = cmd.trimStart();
+    if (trimmed.length <= maxLen) return trimmed;
+    return trimmed.slice(0, maxLen) + "…";
   }
 
   /**
@@ -930,10 +941,7 @@ export default function (pi: ExtensionAPI) {
         sandboxInitialized &&
         commandIsUnsandboxed(command, unsandboxedPatterns)
       ) {
-        const displayCmd =
-          command.trimStart().length > 80
-            ? command.trimStart().slice(0, 80) + "…"
-            : command.trimStart();
+        const displayCmd = truncateCmd(command);
         const level = getUnsandboxedCommandLevel(command, ctx.cwd, sessionUnsandboxedCommands);
         ctx.ui.notify(`🔓 Sandbox disabled: "${displayCmd}" (${level} config)`, "warning");
         auditLog({
@@ -989,10 +997,7 @@ export default function (pi: ExtensionAPI) {
           const choice = await promptBypassBlock(ctx, command, extractErrorSnippet(outputText));
 
           if (choice === "abort") {
-            const displayCmd =
-              command.trimStart().length > 80
-                ? command.trimStart().slice(0, 80) + "…"
-                : command.trimStart();
+            const displayCmd = truncateCmd(command);
             ctx.ui.notify(`🛡️  Kept sandboxed: "${displayCmd}"`, "info");
             pi.sendMessage(
               {
@@ -1013,10 +1018,7 @@ export default function (pi: ExtensionAPI) {
               unsandboxed: false,
             });
           } else {
-            const displayCmd =
-              command.trimStart().length > 80
-                ? command.trimStart().slice(0, 80) + "…"
-                : command.trimStart();
+            const displayCmd = truncateCmd(command);
             const normalized = command.trimStart().split(/\s+/).join(" ");
 
             if (choice === "session") {
@@ -1180,10 +1182,7 @@ export default function (pi: ExtensionAPI) {
     // Predictive bypass: user-configured unsandboxed commands
     const unsandboxedPatterns = getEffectiveUnsandboxedCommands(ctx.cwd);
     if (commandIsUnsandboxed(event.command, unsandboxedPatterns)) {
-      const displayCmd =
-        event.command.trimStart().length > 80
-          ? event.command.trimStart().slice(0, 80) + "…"
-          : event.command.trimStart();
+      const displayCmd = truncateCmd(event.command);
       const level = getUnsandboxedCommandLevel(event.command, ctx.cwd, sessionUnsandboxedCommands);
       ctx.ui.notify(`🔓 Sandbox disabled: "${displayCmd}" (${level} config)`, "warning");
       auditLog({
@@ -1233,10 +1232,7 @@ export default function (pi: ExtensionAPI) {
       const choice = await promptBypassBlock(ctx, event.command, extractErrorSnippet(output));
 
       if (choice === "abort") {
-        const displayCmd =
-          event.command.trimStart().length > 80
-            ? event.command.trimStart().slice(0, 80) + "…"
-            : event.command.trimStart();
+        const displayCmd = truncateCmd(event.command);
         ctx.ui.notify(`🛡️  Kept sandboxed: "${displayCmd}"`, "info");
         pi.sendMessage(
           {
@@ -1278,10 +1274,7 @@ export default function (pi: ExtensionAPI) {
               : choice === "project"
                 ? "project"
                 : "global";
-        const displayCmd =
-          event.command.trimStart().length > 80
-            ? event.command.trimStart().slice(0, 80) + "…"
-            : event.command.trimStart();
+        const displayCmd = truncateCmd(event.command);
 
         ctx.ui.notify(
           `🔓 Retried without sandbox: "${displayCmd}" (exact match, ${bypassLabel})`,

--- a/index.ts
+++ b/index.ts
@@ -1482,9 +1482,29 @@ export default function (pi: ExtensionAPI) {
     }
   });
 
-  // ── session_start ───────────────────────────────────────────────────────────
+  // ── session_start — restore persisted state, then init sandbox ────────────
 
   pi.on("session_start", async (_event, ctx) => {
+    // Restore session allowances from previous execution (survives reload)
+    for (const entry of ctx.sessionManager.getEntries()) {
+      if (entry.type === "custom" && entry.customType === "sandbox-session") {
+        const data = entry.data as {
+          sessionAllowedDomains?: string[];
+          sessionAllowedReadPaths?: string[];
+          sessionAllowedWritePaths?: string[];
+          sessionUnsandboxedCommands?: string[];
+        };
+        if (data.sessionAllowedDomains) sessionAllowedDomains.push(...data.sessionAllowedDomains);
+        if (data.sessionAllowedReadPaths)
+          sessionAllowedReadPaths.push(...data.sessionAllowedReadPaths);
+        if (data.sessionAllowedWritePaths)
+          sessionAllowedWritePaths.push(...data.sessionAllowedWritePaths);
+        if (data.sessionUnsandboxedCommands)
+          sessionUnsandboxedCommands.push(...data.sessionUnsandboxedCommands);
+        break; // Only read the most recent entry
+      }
+    }
+
     const noSandbox = pi.getFlag("no-sandbox") as boolean;
 
     if (noSandbox) {
@@ -1560,9 +1580,23 @@ export default function (pi: ExtensionAPI) {
     }
   });
 
-  // ── session_shutdown ────────────────────────────────────────────────────────
+  // ── session_shutdown — persist + cleanup ────────────────────────────────────
 
   pi.on("session_shutdown", async () => {
+    // Save session allowances so they survive reload
+    if (
+      sessionAllowedDomains.length > 0 ||
+      sessionAllowedReadPaths.length > 0 ||
+      sessionAllowedWritePaths.length > 0 ||
+      sessionUnsandboxedCommands.length > 0
+    ) {
+      pi.appendEntry("sandbox-session", {
+        sessionAllowedDomains: [...sessionAllowedDomains],
+        sessionAllowedReadPaths: [...sessionAllowedReadPaths],
+        sessionAllowedWritePaths: [...sessionAllowedWritePaths],
+        sessionUnsandboxedCommands: [...sessionUnsandboxedCommands],
+      });
+    }
     sessionAllowedDomains.length = 0;
     sessionAllowedReadPaths.length = 0;
     sessionAllowedWritePaths.length = 0;

--- a/index.ts
+++ b/index.ts
@@ -1495,10 +1495,9 @@ export default function (pi: ExtensionAPI) {
     }
   });
 
-  // ── session_start — restore persisted state, then init sandbox ────────────
+  // ── session persistence ─────────────────────────────────────────────────────
 
-  pi.on("session_start", async (_event, ctx) => {
-    // Restore session allowances from previous execution (survives reload)
+  async function restoreSessionState(ctx: ExtensionContext): Promise<void> {
     for (const entry of ctx.sessionManager.getEntries()) {
       if (entry.type === "custom" && entry.customType === "sandbox-session") {
         const data = entry.data as {
@@ -1525,6 +1524,32 @@ export default function (pi: ExtensionAPI) {
         }
       }
     }
+  }
+
+  async function persistSessionState(): Promise<void> {
+    if (
+      sessionAllowedDomains.length > 0 ||
+      sessionAllowedReadPaths.length > 0 ||
+      sessionAllowedWritePaths.length > 0 ||
+      sessionUnsandboxedCommands.length > 0
+    ) {
+      await pi.appendEntry("sandbox-session", {
+        sessionAllowedDomains: [...sessionAllowedDomains],
+        sessionAllowedReadPaths: [...sessionAllowedReadPaths],
+        sessionAllowedWritePaths: [...sessionAllowedWritePaths],
+        sessionUnsandboxedCommands: [...sessionUnsandboxedCommands],
+      });
+    }
+    sessionAllowedDomains.length = 0;
+    sessionAllowedReadPaths.length = 0;
+    sessionAllowedWritePaths.length = 0;
+    sessionUnsandboxedCommands.length = 0;
+  }
+
+  // ── session_start — restore persisted state, then init sandbox ────────────
+
+  pi.on("session_start", async (_event, ctx) => {
+    await restoreSessionState(ctx);
 
     const noSandbox = pi.getFlag("no-sandbox") as boolean;
 
@@ -1604,24 +1629,7 @@ export default function (pi: ExtensionAPI) {
   // ── session_shutdown — persist + cleanup ────────────────────────────────────
 
   pi.on("session_shutdown", async () => {
-    // Save session allowances so they survive reload
-    if (
-      sessionAllowedDomains.length > 0 ||
-      sessionAllowedReadPaths.length > 0 ||
-      sessionAllowedWritePaths.length > 0 ||
-      sessionUnsandboxedCommands.length > 0
-    ) {
-      await pi.appendEntry("sandbox-session", {
-        sessionAllowedDomains: [...sessionAllowedDomains],
-        sessionAllowedReadPaths: [...sessionAllowedReadPaths],
-        sessionAllowedWritePaths: [...sessionAllowedWritePaths],
-        sessionUnsandboxedCommands: [...sessionUnsandboxedCommands],
-      });
-    }
-    sessionAllowedDomains.length = 0;
-    sessionAllowedReadPaths.length = 0;
-    sessionAllowedWritePaths.length = 0;
-    sessionUnsandboxedCommands.length = 0;
+    await persistSessionState();
     if (sandboxInitialized) {
       try {
         await SandboxManager.reset();
@@ -1771,7 +1779,9 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.registerCommand("sandbox-debug", {
-    description: "Debug sandbox config loading",
+    description:
+      "Debug sandbox config loading. Use when confused about permissions, " +
+      "why a path/domain is blocked, or why an action is denied without apparent reason.",
     handler: async (_args, ctx) => {
       const config = loadConfig(ctx.cwd);
       const { globalPath, projectPath } = getConfigPaths(ctx.cwd);

--- a/index.ts
+++ b/index.ts
@@ -91,6 +91,7 @@ interface SandboxConfig extends SandboxRuntimeConfig {
    * Commands that always run unsandboxed (e.g. ["gh auth token"]).
    * Matched by exact full command string. Persists via config file.
    * Override via "unsandboxedCommands" key in sandbox.json.
+   * Global and project configs are merged additively (set union).
    */
   unsandboxedCommands?: string[];
   /**
@@ -644,7 +645,6 @@ export default function (pi: ExtensionAPI) {
     return [
       { label: labels.once, key: "o", action: "once" },
       { label: labels.session, key: "s", action: "session" },
-      { label: labels.abort, key: "esc", action: "abort" },
       {
         label: labels.project,
         key: "P",
@@ -659,6 +659,7 @@ export default function (pi: ExtensionAPI) {
         confirm: true,
         hint: "→ ~/.pi/agent/sandbox.json",
       },
+      { label: labels.abort, key: "esc", action: "abort" },
     ];
   }
 

--- a/index.ts
+++ b/index.ts
@@ -636,9 +636,9 @@ export default function (pi: ExtensionAPI) {
   interface PromptLabels {
     once: string;
     session: string;
-    abort: string;
     project: string;
     global: string;
+    abort: string;
   }
 
   function buildPromptOptions(labels: PromptLabels): PromptOption[] {
@@ -666,17 +666,17 @@ export default function (pi: ExtensionAPI) {
   const PERMISSION_OPTIONS = buildPromptOptions({
     once: "Allow once",
     session: "Allow for this session only",
-    abort: "Abort (keep blocked)",
     project: "Allow for this project",
     global: "Allow for all projects",
+    abort: "Abort (keep blocked)",
   });
 
   const BYPASS_OPTIONS = buildPromptOptions({
     once: "Retry without sandbox (once)",
     session: "Retry without sandbox in this session",
-    abort: "Abort (keep failed result)",
     project: "Retry without sandbox for this project",
     global: "Retry without sandbox for all projects",
+    abort: "Abort (keep failed result)",
   });
 
   /** True if the key event is a navigation key (arrows, enter, escape). */

--- a/index.ts
+++ b/index.ts
@@ -159,19 +159,16 @@ function getUnsandboxedCommandLevel(
   cwd: string,
   sessionCommands: string[],
 ): "project-config" | "global-config" | "session" {
-  const normalized = command.trimStart().split(/\s+/).join(" ");
+  const normalized = normalizeCmd(command);
 
-  // Check session first
-  if (sessionCommands.includes(normalized)) {
-    return "session";
-  }
+  if (sessionCommands.includes(normalized)) return "session";
 
-  // Check project config
+  // Check project config (normalize on read to handle manual edits)
   const projectConfigPath = join(cwd, ".pi", "sandbox.json");
   if (existsSync(projectConfigPath)) {
     try {
       const projectConfig = JSON.parse(readFileSync(projectConfigPath, "utf-8"));
-      if (projectConfig.unsandboxedCommands?.includes(normalized)) {
+      if ((projectConfig.unsandboxedCommands as string[] | undefined)?.map(normalizeCmd).includes(normalized)) {
         return "project-config";
       }
     } catch {
@@ -179,12 +176,12 @@ function getUnsandboxedCommandLevel(
     }
   }
 
-  // Check global config
+  // Check global config (normalize on read to handle manual edits)
   const globalConfigPath = join(getAgentDir(), "sandbox.json");
   if (existsSync(globalConfigPath)) {
     try {
       const globalConfig = JSON.parse(readFileSync(globalConfigPath, "utf-8"));
-      if (globalConfig.unsandboxedCommands?.includes(normalized)) {
+      if ((globalConfig.unsandboxedCommands as string[] | undefined)?.map(normalizeCmd).includes(normalized)) {
         return "global-config";
       }
     } catch {
@@ -192,7 +189,6 @@ function getUnsandboxedCommandLevel(
     }
   }
 
-  // Fallback — shouldn't happen if commandIsUnsandboxed matched
   return "project-config";
 }
 
@@ -331,7 +327,7 @@ const DEFAULT_FAILURE_PATTERNS: string[] = [
  * Check if a command starts with any of the unsandboxed patterns.
  */
 function commandIsUnsandboxed(command: string, patterns: string[]): boolean {
-  const normalized = command.trimStart().split(/\s+/).join(" ");
+  const normalized = normalizeCmd(command);
   return patterns.some((p) => normalized === p);
 }
 
@@ -355,6 +351,21 @@ function extractBlockedWritePath(output: string): string | null {
 }
 
 // ── Path pattern matching ─────────────────────────────────────────────────────
+
+// ── Action label helper ───────────────────────────────────────────────────────
+
+/** Convert an Action enum to a human-readable label. */
+function actionLabel(action: "abort" | "session" | "project" | "global" | "once" | "project-config" | "global-config" | "declined"): string {
+  return action === "once" ? "once" : action === "session" ? "session"
+    : action === "project" ? "project" : "global";
+}
+
+// ── Command normalization ─────────────────────────────────────────────────────
+
+/** Normalize a command for consistent comparison. Trims, collapses whitespace. */
+function normalizeCmd(cmd: string): string {
+  return cmd.trim().split(/\s+/).join(" ");
+}
 
 function matchesPattern(filePath: string, patterns: string[]): boolean {
   const expanded = filePath.replace(/^~/, homedir());
@@ -392,9 +403,16 @@ function readOrEmptyConfig(configPath: string): Partial<SandboxConfig> {
   }
 }
 
-function writeConfigFile(configPath: string, config: Partial<SandboxConfig>): void {
-  mkdirSync(dirname(configPath), { recursive: true });
-  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+/** Returns true on success, false if the file could not be written. */
+function writeConfigFile(configPath: string, config: Partial<SandboxConfig>): boolean {
+  try {
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+    return true;
+  } catch (e) {
+    console.error(`Failed to write config ${configPath}: ${e}`);
+    return false;
+  }
 }
 
 function addDomainToConfig(configPath: string, domain: string): void {
@@ -442,7 +460,7 @@ function addWritePathToConfig(configPath: string, pathToAdd: string): void {
 function addUnsandboxedCommandToConfig(configPath: string, command: string): void {
   const config = readOrEmptyConfig(configPath);
   const existing = config.unsandboxedCommands ?? [];
-  const normalized = command.trimStart().split(/\s+/).join(" ");
+  const normalized = normalizeCmd(command);
   if (normalized && !existing.includes(normalized)) {
     config.unsandboxedCommands = [...existing, normalized];
     writeConfigFile(configPath, config);
@@ -564,7 +582,7 @@ export default function (pi: ExtensionAPI) {
 
   function getEffectiveUnsandboxedCommands(cwd: string): string[] {
     const config = loadConfig(cwd);
-    return [...(config.unsandboxedCommands ?? []), ...sessionUnsandboxedCommands];
+    return [...(config.unsandboxedCommands ?? []).map(normalizeCmd), ...sessionUnsandboxedCommands];
   }
 
   // ── Sandbox reinitialize ────────────────────────────────────────────────────
@@ -588,7 +606,7 @@ export default function (pi: ExtensionAPI) {
           filesystem: {
             ...config.filesystem,
             denyRead: config.filesystem?.denyRead ?? [],
-            allowRead: config.filesystem?.allowRead ?? [],
+            allowRead: [...(config.filesystem?.allowRead ?? []), ...sessionAllowedReadPaths],
             allowWrite: [...(config.filesystem?.allowWrite ?? []), ...sessionAllowedWritePaths],
             denyWrite: config.filesystem?.denyWrite ?? [],
           },
@@ -856,13 +874,19 @@ export default function (pi: ExtensionAPI) {
     cwd: string,
   ): Promise<void> {
     const { globalPath, projectPath } = getConfigPaths(cwd);
-    if (choice !== "once" && !sessionAllowedDomains.includes(domain))
-      sessionAllowedDomains.push(domain);
+    if (choice === "session") sessionAllowedDomains.push(domain);
     if (choice === "project") addDomainToConfig(projectPath, domain);
     if (choice === "global") addDomainToConfig(globalPath, domain);
-    if (choice === "once") sessionAllowedDomains.push(domain);
+    if (choice === "once") {
+      sessionAllowedDomains.push(domain);
+      try {
+        await reinitializeSandbox(cwd);
+      } finally {
+        sessionAllowedDomains.pop();
+      }
+      return;
+    }
     await reinitializeSandbox(cwd);
-    if (choice === "once") sessionAllowedDomains.pop();
   }
 
   async function applyReadChoice(
@@ -871,13 +895,19 @@ export default function (pi: ExtensionAPI) {
     cwd: string,
   ): Promise<void> {
     const { globalPath, projectPath } = getConfigPaths(cwd);
-    if (choice !== "once" && !sessionAllowedReadPaths.includes(filePath))
-      sessionAllowedReadPaths.push(filePath);
+    if (choice === "session") sessionAllowedReadPaths.push(filePath);
     if (choice === "project") addReadPathToConfig(projectPath, filePath);
     if (choice === "global") addReadPathToConfig(globalPath, filePath);
-    if (choice === "once") sessionAllowedReadPaths.push(filePath);
+    if (choice === "once") {
+      sessionAllowedReadPaths.push(filePath);
+      try {
+        await reinitializeSandbox(cwd);
+      } finally {
+        sessionAllowedReadPaths.pop();
+      }
+      return;
+    }
     await reinitializeSandbox(cwd);
-    if (choice === "once") sessionAllowedReadPaths.pop();
   }
 
   async function applyWriteChoice(
@@ -886,13 +916,19 @@ export default function (pi: ExtensionAPI) {
     cwd: string,
   ): Promise<void> {
     const { globalPath, projectPath } = getConfigPaths(cwd);
-    if (choice !== "once" && !sessionAllowedWritePaths.includes(filePath))
-      sessionAllowedWritePaths.push(filePath);
+    if (choice === "session") sessionAllowedWritePaths.push(filePath);
     if (choice === "project") addWritePathToConfig(projectPath, filePath);
     if (choice === "global") addWritePathToConfig(globalPath, filePath);
-    if (choice === "once") sessionAllowedWritePaths.push(filePath);
+    if (choice === "once") {
+      sessionAllowedWritePaths.push(filePath);
+      try {
+        await reinitializeSandbox(cwd);
+      } finally {
+        sessionAllowedWritePaths.pop();
+      }
+      return;
+    }
     await reinitializeSandbox(cwd);
-    if (choice === "once") sessionAllowedWritePaths.pop();
   }
 
   /** Truncate a command string for display, keeping maxLen chars. */
@@ -942,7 +978,7 @@ export default function (pi: ExtensionAPI) {
         ctx.ui.notify(`🔓 Sandbox disabled: "${displayCmd}" (${level} config)`, "warning");
         auditLog({
           timestamp: new Date().toISOString(),
-          command: command.trimStart().split(/\s+/).join(" "),
+          command: normalizeCmd(command),
           type: "predictive",
           choice: level,
           unsandboxed: true,
@@ -1008,14 +1044,14 @@ export default function (pi: ExtensionAPI) {
             );
             auditLog({
               timestamp: new Date().toISOString(),
-              command: command.trimStart().split(/\s+/).join(" "),
+              command: normalizeCmd(command),
               type: "reactive",
               choice: "declined",
               unsandboxed: false,
             });
           } else {
             const displayCmd = truncateCmd(command);
-            const normalized = command.trimStart().split(/\s+/).join(" ");
+            const normalized = normalizeCmd(command);
 
             if (choice === "session") {
               if (normalized && !sessionUnsandboxedCommands.includes(normalized)) {
@@ -1027,14 +1063,7 @@ export default function (pi: ExtensionAPI) {
               addUnsandboxedCommandToConfig(getConfigPaths(ctx.cwd).globalPath, command);
             }
 
-            const bypassLabel =
-              choice === "once"
-                ? "once"
-                : choice === "session"
-                  ? "session"
-                  : choice === "project"
-                    ? "project"
-                    : "global";
+            const bypassLabel = actionLabel(choice);
 
             ctx.ui.notify(
               `🔓 Retried without sandbox: "${displayCmd}" (exact match, ${bypassLabel})`,
@@ -1072,14 +1101,7 @@ export default function (pi: ExtensionAPI) {
           const choice = await promptWriteBlock(ctx, blockedPath);
           if (choice !== "abort") {
             await applyWriteChoice(choice, blockedPath, ctx.cwd);
-            const level =
-              choice === "once"
-                ? "once"
-                : choice === "session"
-                  ? "session"
-                  : choice === "project"
-                    ? "project"
-                    : "global";
+            const level = actionLabel(choice);
             ctx.ui.notify(`📝 Write path "${blockedPath}" allowed (${level})`, "info");
             pi.sendMessage(
               {
@@ -1093,7 +1115,7 @@ export default function (pi: ExtensionAPI) {
               timestamp: new Date().toISOString(),
               command: blockedPath,
               type: "predictive",
-              choice: level,
+              choice,
               unsandboxed: false,
             });
 
@@ -1148,14 +1170,7 @@ export default function (pi: ExtensionAPI) {
           };
         }
         await applyDomainChoice(choice, domain, ctx.cwd);
-        const level =
-          choice === "once"
-            ? "once"
-            : choice === "session"
-              ? "session"
-              : choice === "project"
-                ? "project"
-                : "global";
+        const level = actionLabel(choice);
         ctx.ui.notify(`🌐 Domain "${domain}" allowed (${level})`, "info");
         pi.sendMessage(
           {
@@ -1169,7 +1184,7 @@ export default function (pi: ExtensionAPI) {
           timestamp: new Date().toISOString(),
           command: domain,
           type: "predictive",
-          choice: level,
+          choice,
           unsandboxed: false,
         });
       }
@@ -1183,7 +1198,7 @@ export default function (pi: ExtensionAPI) {
       ctx.ui.notify(`🔓 Sandbox disabled: "${displayCmd}" (${level} config)`, "warning");
       auditLog({
         timestamp: new Date().toISOString(),
-        command: event.command.trimStart().split(/\s+/).join(" "),
+        command: normalizeCmd(event.command),
         type: "predictive",
         choice: level,
         unsandboxed: true,
@@ -1243,13 +1258,13 @@ export default function (pi: ExtensionAPI) {
         );
         auditLog({
           timestamp: new Date().toISOString(),
-          command: event.command.trimStart().split(/\s+/).join(" "),
+          command: normalizeCmd(event.command),
           type: "reactive",
           choice: "declined",
           unsandboxed: false,
         });
       } else {
-        const normalized = event.command.trimStart().split(/\s+/).join(" ");
+        const normalized = normalizeCmd(event.command);
         if (
           choice === "session" &&
           normalized &&
@@ -1262,14 +1277,7 @@ export default function (pi: ExtensionAPI) {
           addUnsandboxedCommandToConfig(getConfigPaths(ctx.cwd).globalPath, event.command);
         }
 
-        const bypassLabel =
-          choice === "once"
-            ? "once"
-            : choice === "session"
-              ? "session"
-              : choice === "project"
-                ? "project"
-                : "global";
+        const bypassLabel = actionLabel(choice);
         const displayCmd = truncateCmd(event.command);
 
         ctx.ui.notify(
@@ -1347,14 +1355,7 @@ export default function (pi: ExtensionAPI) {
             };
           }
           await applyDomainChoice(choice, domain, ctx.cwd);
-          const level =
-            choice === "once"
-              ? "once"
-              : choice === "session"
-                ? "session"
-                : choice === "project"
-                  ? "project"
-                  : "global";
+          const level = actionLabel(choice);
           ctx.ui.notify(`🌐 Domain "${domain}" allowed (${level})`, "info");
           pi.sendMessage(
             {
@@ -1368,7 +1369,7 @@ export default function (pi: ExtensionAPI) {
             timestamp: new Date().toISOString(),
             command: domain,
             type: "predictive",
-            choice: level,
+            choice,
             unsandboxed: false,
           });
         }
@@ -1394,14 +1395,7 @@ export default function (pi: ExtensionAPI) {
           };
         }
         await applyReadChoice(choice, filePath, ctx.cwd);
-        const level =
-          choice === "once"
-            ? "once"
-            : choice === "session"
-              ? "session"
-              : choice === "project"
-                ? "project"
-                : "global";
+        const level = actionLabel(choice);
         ctx.ui.notify(`📖 Read path "${filePath}" allowed (${level})`, "info");
         pi.sendMessage(
           {
@@ -1415,7 +1409,7 @@ export default function (pi: ExtensionAPI) {
           timestamp: new Date().toISOString(),
           command: filePath,
           type: "predictive",
-          choice: level,
+          choice,
           unsandboxed: false,
         });
         // Allowed — fall through, tool runs.
@@ -1438,14 +1432,7 @@ export default function (pi: ExtensionAPI) {
           };
         }
         await applyWriteChoice(choice, path, ctx.cwd);
-        const level =
-          choice === "once"
-            ? "once"
-            : choice === "session"
-              ? "session"
-              : choice === "project"
-                ? "project"
-                : "global";
+        const level = actionLabel(choice);
         ctx.ui.notify(`📝 Write path "${path}" allowed (${level})`, "info");
         pi.sendMessage(
           {
@@ -1459,7 +1446,7 @@ export default function (pi: ExtensionAPI) {
           timestamp: new Date().toISOString(),
           command: path,
           type: "predictive",
-          choice: level,
+          choice,
           unsandboxed: false,
         });
 
@@ -1494,7 +1481,8 @@ export default function (pi: ExtensionAPI) {
   // ── session persistence ─────────────────────────────────────────────────────
 
   async function restoreSessionState(ctx: ExtensionContext): Promise<void> {
-    for (const entry of ctx.sessionManager.getEntries()) {
+    try {
+      for (const entry of ctx.sessionManager.getEntries()) {
       if (entry.type === "custom" && entry.customType === "sandbox-session") {
         const data = entry.data as {
           sessionAllowedDomains?: string[];
@@ -1520,6 +1508,9 @@ export default function (pi: ExtensionAPI) {
         }
       }
     }
+    } catch {
+      // Silently ignore restoration errors — sandbox init proceeds without session state
+    }
   }
 
   async function persistSessionState(): Promise<void> {
@@ -1529,12 +1520,16 @@ export default function (pi: ExtensionAPI) {
       sessionAllowedWritePaths.length > 0 ||
       sessionUnsandboxedCommands.length > 0
     ) {
-      await pi.appendEntry("sandbox-session", {
-        sessionAllowedDomains: [...sessionAllowedDomains],
-        sessionAllowedReadPaths: [...sessionAllowedReadPaths],
-        sessionAllowedWritePaths: [...sessionAllowedWritePaths],
-        sessionUnsandboxedCommands: [...sessionUnsandboxedCommands],
-      });
+      try {
+        await pi.appendEntry("sandbox-session", {
+          sessionAllowedDomains: [...sessionAllowedDomains],
+          sessionAllowedReadPaths: [...sessionAllowedReadPaths],
+          sessionAllowedWritePaths: [...sessionAllowedWritePaths],
+          sessionUnsandboxedCommands: [...sessionUnsandboxedCommands],
+        });
+      } catch {
+        // If saving fails, don't clear — allowances survive the current session
+      }
     }
     sessionAllowedDomains.length = 0;
     sessionAllowedReadPaths.length = 0;
@@ -1802,7 +1797,7 @@ export default function (pi: ExtensionAPI) {
       ];
 
       const testCmd = 'security find-generic-password -s "test" 2>&1 | head -3';
-      const normalized = testCmd.trimStart().split(/\s+/).join(" ");
+      const normalized = normalizeCmd(testCmd);
       const patterns = getEffectiveUnsandboxedCommands(ctx.cwd);
       lines.push(`  test command: ${testCmd}`);
       lines.push(`  normalized: ${normalized}`);

--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,8 @@
  * Based on https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/examples/extensions/sandbox/index.ts
  * by Mario Zechner, used under the MIT License.
  *
- * Sandbox Extension - OS-level sandboxing for pi with interactive permission prompts.
+ * Sandbox Extension - OS-level sandboxing for bash commands, plus path policy
+ * enforcement for pi's read/write/edit tools, with interactive permission prompts.
  *
  * Uses @carderne/sandbox-runtime to enforce filesystem and network
  * restrictions on bash commands at the OS level (sandbox-exec on macOS,
@@ -87,8 +88,9 @@ import { matchesKey, Key, truncateToWidth } from "@mariozechner/pi-tui";
 interface SandboxConfig extends SandboxRuntimeConfig {
   enabled?: boolean;
   /**
-   * Commands that always run unsandboxed (e.g. ["gh", "security"]).
-   * Matched by first word; persists across sessions.
+   * Commands that always run unsandboxed (e.g. ["gh auth token"]).
+   * Matched by exact full command string. Persists via config file.
+   * Override via "unsandboxedCommands" key in sandbox.json.
    */
   unsandboxedCommands?: string[];
   /**
@@ -100,7 +102,6 @@ interface SandboxConfig extends SandboxRuntimeConfig {
 
 const DEFAULT_CONFIG: SandboxConfig = {
   enabled: true,
-  unsandboxedCommands: [],
   network: {
     allowedDomains: [
       "npmjs.org",
@@ -124,12 +125,19 @@ const DEFAULT_CONFIG: SandboxConfig = {
   },
 };
 
-const AUDIT_LOG = join(homedir(), ".pi", "sandbox", "audit.log");
+const AUDIT_LOG = join(homedir(), ".pi", "agent", "sandbox", "audit.log");
 function auditLog(entry: {
   timestamp: string;
   command: string;
   type: "predictive" | "reactive";
-  choice: "once" | "session" | "project" | "global" | "project-level" | "system-level" | "declined";
+  choice:
+    | "once"
+    | "session"
+    | "project"
+    | "global"
+    | "project-config"
+    | "global-config"
+    | "declined";
   unsandboxed: boolean;
 }): void {
   try {
@@ -143,14 +151,14 @@ function auditLog(entry: {
 
 /**
  * Determine the config level for an unsandboxed command.
- * Returns "project-level", "system-level", or "session" based on which config
- * contains the command.
+ * Returns "project-config", "global-config", or "session" based on which config
+ * contains the command. "-config" suffix means no user interaction occurred.
  */
 function getUnsandboxedCommandLevel(
   command: string,
   cwd: string,
   sessionCommands: string[],
-): "project-level" | "system-level" | "session" {
+): "project-config" | "global-config" | "session" {
   const normalized = command.trimStart().split(/\s+/).join(" ");
 
   // Check session first
@@ -164,7 +172,7 @@ function getUnsandboxedCommandLevel(
     try {
       const projectConfig = JSON.parse(readFileSync(projectConfigPath, "utf-8"));
       if (projectConfig.unsandboxedCommands?.includes(normalized)) {
-        return "project-level";
+        return "project-config";
       }
     } catch {
       /* ignore */
@@ -177,7 +185,7 @@ function getUnsandboxedCommandLevel(
     try {
       const globalConfig = JSON.parse(readFileSync(globalConfigPath, "utf-8"));
       if (globalConfig.unsandboxedCommands?.includes(normalized)) {
-        return "system-level";
+        return "global-config";
       }
     } catch {
       /* ignore */
@@ -185,7 +193,7 @@ function getUnsandboxedCommandLevel(
   }
 
   // Fallback — shouldn't happen if commandIsUnsandboxed matched
-  return "project-level";
+  return "project-config";
 }
 
 function loadConfig(cwd: string): SandboxConfig {
@@ -621,7 +629,7 @@ export default function (pi: ExtensionAPI) {
     },
     {
       label: "Allow for all projects",
-      key: "A",
+      key: "G",
       action: "global",
       confirm: true,
       hint: "→ ~/.pi/agent/sandbox.json",
@@ -641,7 +649,7 @@ export default function (pi: ExtensionAPI) {
     },
     {
       label: "Retry without sandbox for all projects",
-      key: "A",
+      key: "G",
       action: "global",
       confirm: true,
       hint: "→ ~/.pi/agent/sandbox.json",

--- a/index.ts
+++ b/index.ts
@@ -630,7 +630,7 @@ export default function (pi: ExtensionAPI) {
   function recordDecisionAndNotify(
     ctx: ExtensionContext,
     decision: {
-      action: "bypass-predictive" | "bypass-retry" | "bypass-declined" | "domain-allowed" | "read-allowed" | "write-allowed";
+      action: "bypass-predictive" | "bypass-retry" | "bypass-declined" | "domain-allowed" | "read-allowed" | "write-allowed" | "domain-denied" | "read-denied" | "write-denied";
       target: string;
       choice: string;
     },
@@ -679,6 +679,19 @@ export default function (pi: ExtensionAPI) {
       case "write-allowed":
         notifyMsg = `📝 Write path "${target}" allowed (${choice})`;
         sendMsg = `User allowed write path "${target}" (${choice})`;
+        break;
+      case "domain-denied":
+        notifyMsg = `🚫 Domain "${target}" denied`;
+        sendMsg = `User denied network access to "${target}"`;
+        level = "warning";
+        break;
+      case "read-denied":
+        notifyMsg = `🚫 Read path "${target}" denied`;
+        sendMsg = `User denied read access to "${target}"`;
+        break;
+      case "write-denied":
+        notifyMsg = `🚫 Write path "${target}" denied`;
+        sendMsg = `User denied write access to "${target}"`;
         break;
     }
 
@@ -1174,6 +1187,11 @@ export default function (pi: ExtensionAPI) {
       if (!domainIsAllowed(domain, effectiveDomains)) {
         const choice = await promptDomainBlock(ctx, domain);
         if (choice === "abort") {
+          recordDecisionAndNotify(ctx, {
+            action: "domain-denied",
+            target: domain,
+            choice: "abort",
+          });
           return {
             result: {
               output: `Blocked: "${domain}" is not in allowedDomains. Use /sandbox to review your config.`,
@@ -1306,6 +1324,11 @@ export default function (pi: ExtensionAPI) {
         if (!domainIsAllowed(domain, effectiveDomains)) {
           const choice = await promptDomainBlock(ctx, domain);
           if (choice === "abort") {
+            recordDecisionAndNotify(ctx, {
+              action: "domain-denied",
+              target: domain,
+              choice: "abort",
+            });
             return {
               block: true,
               reason: `Network access to "${domain}" is blocked (not in allowedDomains).`,
@@ -1335,6 +1358,11 @@ export default function (pi: ExtensionAPI) {
       if (!matchesPattern(filePath, effectiveAllowRead)) {
         const choice = await promptReadBlock(ctx, filePath);
         if (choice === "abort") {
+          recordDecisionAndNotify(ctx, {
+            action: "read-denied",
+            target: filePath,
+            choice: "abort",
+          });
           return {
             block: true,
             reason: `Sandbox: read access denied for "${filePath}"`,
@@ -1361,6 +1389,11 @@ export default function (pi: ExtensionAPI) {
       if (shouldPromptForWrite(path, allowWrite, matchesPattern)) {
         const choice = await promptWriteBlock(ctx, path);
         if (choice === "abort") {
+          recordDecisionAndNotify(ctx, {
+            action: "write-denied",
+            target: path,
+            choice: "abort",
+          });
           return {
             block: true,
             reason: `Sandbox: write access denied for "${path}" (not in allowWrite)`,

--- a/index.ts
+++ b/index.ts
@@ -894,7 +894,31 @@ export default function (pi: ExtensionAPI) {
         return sandboxedBash.execute(id, params, signal, onUpdate);
       };
 
-      const runUnsandboxed = () => localBash.execute(id, params, signal, onUpdate);
+      const runUnsandboxed = async () => {
+        const localOps = createLocalBashOperations();
+        let output = "";
+        try {
+          const r = await localOps.exec(command, localCwd, {
+            onData: (chunk) => {
+              output += chunk;
+            },
+          });
+          return {
+            content: [{ type: "text", text: output }],
+            details: { exitCode: r.exitCode },
+          } as any;
+        } catch (e) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Error: ${e instanceof Error ? e.message : String(e)}`,
+              },
+            ],
+            details: { exitCode: 1 },
+          };
+        }
+      };
 
       // Check user-configured unsandboxed patterns first
       const unsandboxedPatterns = getEffectiveUnsandboxedCommands(ctx.cwd);

--- a/index.ts
+++ b/index.ts
@@ -316,6 +316,7 @@ const DEFAULT_FAILURE_PATTERNS: string[] = [
   "terminal prompts disabled",
   "could not read username",
   "permission denied",
+  "requires authentication",
 ];
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -450,7 +450,7 @@ function createSandboxedBashOps(): BashOperations {
         throw new Error(`Working directory does not exist: ${cwd}`);
       }
 
-      const wrappedCommand = await SandboxManager.wrapWithSandbox(command);
+      const wrappedCommand = await SandboxManager.wrapWithSandbox("set -o pipefail && " + command);
 
       return new Promise((resolve, reject) => {
         const child = spawn("bash", ["-c", wrappedCommand], {

--- a/index.ts
+++ b/index.ts
@@ -894,31 +894,7 @@ export default function (pi: ExtensionAPI) {
         return sandboxedBash.execute(id, params, signal, onUpdate);
       };
 
-      const runUnsandboxed = async () => {
-        const localOps = createLocalBashOperations();
-        let output = "";
-        try {
-          const r = await localOps.exec(command, localCwd, {
-            onData: (chunk) => {
-              output += chunk;
-            },
-          });
-          return {
-            content: [{ type: "text", text: output }],
-            details: { exitCode: r.exitCode },
-          } as any;
-        } catch (e) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `Error: ${e instanceof Error ? e.message : String(e)}`,
-              },
-            ],
-            details: { exitCode: 1 },
-          };
-        }
-      };
+      const runUnsandboxed = () => localBash.execute(id, params, signal, onUpdate);
 
       // Check user-configured unsandboxed patterns first
       const unsandboxedPatterns = getEffectiveUnsandboxedCommands(ctx.cwd);

--- a/index.ts
+++ b/index.ts
@@ -1590,7 +1590,7 @@ export default function (pi: ExtensionAPI) {
       sessionAllowedWritePaths.length > 0 ||
       sessionUnsandboxedCommands.length > 0
     ) {
-      pi.appendEntry("sandbox-session", {
+      await pi.appendEntry("sandbox-session", {
         sessionAllowedDomains: [...sessionAllowedDomains],
         sessionAllowedReadPaths: [...sessionAllowedReadPaths],
         sessionAllowedWritePaths: [...sessionAllowedWritePaths],

--- a/index.ts
+++ b/index.ts
@@ -632,45 +632,51 @@ export default function (pi: ExtensionAPI) {
     hint?: string;
   }
 
-  const PERMISSION_OPTIONS: PromptOption[] = [
-    { label: "Allow once", key: "o", action: "once" },
-    { label: "Allow for this session only", key: "s", action: "session" },
-    { label: "Abort (keep blocked)", key: "esc", action: "abort" },
-    {
-      label: "Allow for this project",
-      key: "P",
-      action: "project",
-      confirm: true,
-      hint: "→ .pi/sandbox.json",
-    },
-    {
-      label: "Allow for all projects",
-      key: "G",
-      action: "global",
-      confirm: true,
-      hint: "→ ~/.pi/agent/sandbox.json",
-    },
-  ];
+  interface PromptLabels {
+    once: string;
+    session: string;
+    abort: string;
+    project: string;
+    global: string;
+  }
 
-  const BYPASS_OPTIONS: PromptOption[] = [
-    { label: "Retry without sandbox (once)", key: "o", action: "once" },
-    { label: "Retry without sandbox in this session", key: "s", action: "session" },
-    { label: "Abort (keep failed result)", key: "esc", action: "abort" },
-    {
-      label: "Retry without sandbox for this project",
-      key: "P",
-      action: "project",
-      confirm: true,
-      hint: "→ .pi/sandbox.json",
-    },
-    {
-      label: "Retry without sandbox for all projects",
-      key: "G",
-      action: "global",
-      confirm: true,
-      hint: "→ ~/.pi/agent/sandbox.json",
-    },
-  ];
+  function buildPromptOptions(labels: PromptLabels): PromptOption[] {
+    return [
+      { label: labels.once, key: "o", action: "once" },
+      { label: labels.session, key: "s", action: "session" },
+      { label: labels.abort, key: "esc", action: "abort" },
+      {
+        label: labels.project,
+        key: "P",
+        action: "project",
+        confirm: true,
+        hint: "→ .pi/sandbox.json",
+      },
+      {
+        label: labels.global,
+        key: "G",
+        action: "global",
+        confirm: true,
+        hint: "→ ~/.pi/agent/sandbox.json",
+      },
+    ];
+  }
+
+  const PERMISSION_OPTIONS = buildPromptOptions({
+    once: "Allow once",
+    session: "Allow for this session only",
+    abort: "Abort (keep blocked)",
+    project: "Allow for this project",
+    global: "Allow for all projects",
+  });
+
+  const BYPASS_OPTIONS = buildPromptOptions({
+    once: "Retry without sandbox (once)",
+    session: "Retry without sandbox in this session",
+    abort: "Abort (keep failed result)",
+    project: "Retry without sandbox for this project",
+    global: "Retry without sandbox for all projects",
+  });
 
   /** True if the key event is a navigation key (arrows, enter, escape). */
   function isNavigationKey(data: string): boolean {

--- a/index.ts
+++ b/index.ts
@@ -629,9 +629,9 @@ export default function (pi: ExtensionAPI) {
   ];
 
   const BYPASS_OPTIONS: PromptOption[] = [
-    { label: "Abort (keep failed result)", key: "esc", action: "abort" },
     { label: "Retry without sandbox (once)", key: "o", action: "once" },
     { label: "Retry without sandbox in this session", key: "s", action: "session" },
+    { label: "Abort (keep failed result)", key: "esc", action: "abort" },
     {
       label: "Retry without sandbox for this project",
       key: "P",

--- a/index.ts
+++ b/index.ts
@@ -703,6 +703,11 @@ export default function (pi: ExtensionAPI) {
           },
 
           handleInput(data: string): void {
+            // Passthrough: let pi handle app-level keys (Ctrl+O expand, etc.)
+            if (matchesKey(data, Key.ctrl("o")) || matchesKey(data, Key.ctrl("p"))) {
+              return;
+            }
+
             if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
               resolve("abort");
               return;

--- a/index.ts
+++ b/index.ts
@@ -886,6 +886,7 @@ export default function (pi: ExtensionAPI) {
     label: "bash (sandboxed)",
     async execute(id, params, signal, onUpdate, ctx) {
       const command = (params as { command?: string }).command ?? "";
+      ctx.ui.notify(`NOTIFY TEST: ${command.slice(0, 40)}`, "info");
 
       const runSandboxed = () => {
         const sandboxedBash = createBashTool(localCwd, {

--- a/index.ts
+++ b/index.ts
@@ -458,16 +458,12 @@ function createSandboxedBashOps(): BashOperations {
         throw new Error(`Working directory does not exist: ${cwd}`);
       }
 
-      const wrappedCommand = await SandboxManager.wrapWithSandbox("set -o pipefail && " + command);
+      const wrappedCommand = await SandboxManager.wrapWithSandbox(command);
 
       return new Promise((resolve, reject) => {
         const child = spawn("bash", ["-c", wrappedCommand], {
           cwd,
-          env: {
-            ...env,
-            GIT_TERMINAL_PROMPT: "0",
-            SSH_ASKPASS_REQUIRE: "never",
-          },
+          env: { ...env },
           detached: true,
           stdio: ["ignore", "pipe", "pipe"],
         });

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ci:check": "npm run check"
   },
   "dependencies": {
-    "@carderne/sandbox-runtime": "^0.0.43"
+    "@carderne/sandbox-runtime": "github:cad0p/sandbox-runtime#16c2d2e"
   },
   "peerDependencies": {
     "@mariozechner/pi-coding-agent": "^0.61.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ci:check": "npm run check"
   },
   "dependencies": {
-    "@carderne/sandbox-runtime": "github:cad0p/sandbox-runtime#16c2d2e"
+    "@carderne/sandbox-runtime": "^0.0.43"
   },
   "peerDependencies": {
     "@mariozechner/pi-coding-agent": "^0.61.0"


### PR DESCRIPTION
## Summary

Adds reactive interactive command bypass for sandboxed commands that fail due to OS-level restrictions (keychain access, auth tokens, etc).

## How it works

1. **Run sandboxed first** — all commands execute in the OS sandbox as before
2. **Detect failure** — if output matches configurable failure patterns, prompt the user
3. **User chooses**:
   - `[esc]` Abort (keep failed result)
   - `[o]` Retry without sandbox (once)
   - `[s]` Retry without sandbox in this session (exact command match)
   - `[P]` Retry without sandbox for this project (exact command match) → `.pi/sandbox.json`
   - `[A]` Retry without sandbox for all projects (exact command match) → `~/.pi/agent/sandbox.json`
4. **Predictive shortcut** — pre-configured `unsandboxedCommands` bypass immediately without prompting

## New config fields

| Field | Type | Description |
|-------|------|-------------|
| `unsandboxedCommands` | `string[]` | Commands that always run unsandboxed (exact string match) |
| `sandboxFailurePatterns` | `string[]` | Output patterns that trigger the reactive bypass prompt |

```json
{
  "unsandboxedCommands": ["gh auth token", "security find-generic-password -s test"],
  "sandboxFailurePatterns": ["operation not permitted", "no oauth token"]
}
```

## Env vars for fast-fail

Sandboxed bash processes inject:
- `GIT_TERMINAL_PROMPT=0` — git fails fast instead of hanging on credential prompts
- `SSH_ASKPASS_REQUIRE=never` — SSH fails fast instead of hanging on passphrase
- `set -o pipefail` — pipe exit codes reflect the first failure, not the last command

## Default failure patterns

| Pattern | Catches |
|---------|---------|
| `operation not permitted` | mkdir, touch, write to forbidden paths |
| `no oauth token` | gh CLI auth failures |
| `authentication failed` | Generic auth failures |
| `terminal prompts disabled` | git push/pull without GIT_TERMINAL_PROMPT |
| `could not read username` | git HTTPS auth failures |
| `permission denied` | SSH, file access |
| `requires authentication` | gh API auth failures |
| `user interaction is not allowed` | macOS keychain sandbox |
| `errsecinteractionnotallowed` | macOS securityd block |

## Permission prompts extended

Domain/read/write prompts now include `[o]` Allow once option alongside existing `[esc]`/`[s]`/`[P]`/`[A]`.

## Messaging

All events produce:
- **Visible notification** (user sees toast)
- **Hidden system message** (agent context via `pi.sendMessage({ display: false })`)
- **Audit log entry** at `~/.pi/sandbox/audit.log` (structured JSON)

Notifications explicitly say "exact match" to clarify that session/project/global bypass is for the **specific command string**, not the tool in general.

## Security

- Full **exact-command match** for `unsandboxedCommands` — `git push` does not match `git push && rm -rf /`
- Agent **cannot silently bypass** — every sandboxed failure triggers a user prompt
- Session allowances are **JS memory only** (agent cannot access)
- Config files are in `denyWrite` — agent cannot self-modify
- Predictive shortcut respects exact match security

## Also in this PR

- `allowGitHooks` config support (depends on forked `@carderne/sandbox-runtime`)
- Enhanced audit logging with `mkdirSync` fix for parent directory creation
- Proper `deepMerge` for config arrays (concatenate, don't replace)
- `requires authentication` added to default failure patterns
- Catch-all exception handling in sandboxed bash execution

## Known limitations

- `Ctrl+O` (expand tool output) doesn't work while permission/bypass prompts are showing — this is a pi TUI limitation when `ctx.ui.custom()` is active. Workaround: `esc` to dismiss, expand, re-trigger the prompt.
- Piped commands without `set -o pipefail` may have incorrect exit codes (mitigated by injecting `pipefail`)
- Commands that HANG rather than fail fast need separate handling (`GIT_TERMINAL_PROMPT=0` and `SSH_ASKPASS_REQUIRE=never` handle the common cases)

## Regex note

\`extractBlockedWritePath\` uses \`[^:]+\` (not \`[^\s:]+\`) to capture paths with spaces (e.g. \`/tmp/my file.txt\`). The colon is always present in the bash error format \`path: Operation not permitted\`, so this is safe.