### PR TITLE
Allow trailing / at the end of paths

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -238,7 +238,8 @@ function matchesPattern(filePath: string, patterns: string[]): boolean {
       const escaped = absP.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
       return new RegExp(`^${escaped}$`).test(abs);
     }
-    return abs === absP || abs.startsWith(absP + "/");
+    const sep = absP.endsWith("/") ? "" : "/";
+    return abs === absP || abs.startsWith(absP + sep);
   });
 }
 


### PR DESCRIPTION
At the moment if you specify something like `/opt/` as a path in `allowRead`, it won't work because an additional `/` will be added to the end. This change fixes that.
Additionally, it allows putting literal root in configurations, which was not possible earlier