### PR TITLE
fix: apply session read allowances to sandbox runtime

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -442,7 +442,7 @@ export default function (pi: ExtensionAPI) {
           filesystem: {
             ...config.filesystem,
             denyRead: config.filesystem?.denyRead ?? [],
-            allowRead: config.filesystem?.allowRead ?? [],
+            allowRead: [...(config.filesystem?.allowRead ?? []), ...sessionAllowedReadPaths],
             allowWrite: [...(config.filesystem?.allowWrite ?? []), ...sessionAllowedWritePaths],
             denyWrite: config.filesystem?.denyWrite ?? [],
           },


### PR DESCRIPTION
- merge session-only read allowances into the sandbox runtime config during reinitialization
- keeps bash sandbox reads consistent with /sandbox session read state

Fixes #8