### PR TITLE
feat: emit request-attention event on permission prompts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -522,6 +522,8 @@ export default function (pi: ExtensionAPI) {
   ): Promise<"abort" | "session" | "project" | "global"> {
     if (!ctx.hasUI) return "abort";
 
+    pi.events.emit("request-attention", { message: "Sandbox permission required" });
+
     const result = await ctx.ui.custom<"abort" | "session" | "project" | "global">(
       (tui, theme, _kb, done) => {
         let selectedIndex = 0;


### PR DESCRIPTION
I use both `pi-alert` and `pi-sandbox` and it would be great to integrate them in a way, so I will be notified when `pi-sandbox` shows the prompt. I have already prepared a patch for `pi-alert` to allow such integration, but it's not yet reviewed and merged.

https://github.com/maxpetretta/pi-alert/pull/3