### PR TITLE
Hard-block denyWrite before prompting for allowWrite

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -870,6 +870,16 @@ export default function (pi: ExtensionAPI) {
       const allowWrite = getEffectiveAllowWrite(ctx.cwd);
       const denyWrite = config.filesystem?.denyWrite ?? [];
 
+      // denyWrite takes precedence and is never prompted.
+      if (matchesPattern(path, denyWrite)) {
+        return {
+          block: true,
+          reason:
+            `Sandbox: write access denied for "${path}" (in denyWrite). ` +
+            `To change this, edit denyWrite in:\n  ${projectPath}\n  ${globalPath}`,
+        };
+      }
+
       if (shouldPromptForWrite(path, allowWrite, matchesPattern)) {
         const choice = await promptWriteBlock(ctx, path);
         if (choice === "abort") {
@@ -879,31 +889,8 @@ export default function (pi: ExtensionAPI) {
           };
         }
         await applyWriteChoice(choice, path, ctx.cwd);
-
-        // denyWrite takes precedence — warn if it would still block.
-        if (matchesPattern(path, denyWrite)) {
-          ctx.ui.notify(
-            `⚠️ "${path}" was added to allowWrite, but it is also in denyWrite and will remain blocked.\n` +
-              `Check denyWrite in:\n  ${projectPath}\n  ${globalPath}`,
-            "warning",
-          );
-          return {
-            block: true,
-            reason: `Sandbox: write access denied for "${path}" (also in denyWrite)`,
-          };
-        }
-
         // Allowed — fall through, tool runs.
         return;
-      }
-
-      if (matchesPattern(path, denyWrite)) {
-        return {
-          block: true,
-          reason:
-            `Sandbox: write access denied for "${path}" (in denyWrite). ` +
-            `To change this, edit denyWrite in:\n  ${projectPath}\n  ${globalPath}`,
-        };
       }
     }
   });


### PR DESCRIPTION
**Title:** Hard-block denyWrite before prompting for allowWrite

**Description:**

Fixes a precedence bug in the write/edit `tool_call` handler where `denyWrite` was only consulted *after* the user granted an `allowWrite` prompt. A path that was in `denyWrite` but not `allowWrite` would incorrectly trigger a prompt instead of being hard-blocked, contradicting the documented behavior:

> | Path in `denyWrite` | Hard-blocked, no prompt |
>
> **Write:** `denyWrite` takes precedence over `allowWrite` and is never prompted.

**Change:** Added a `denyWrite` check at the top of the write/edit branch in `pi.on("tool_call", ...)`, before `shouldPromptForWrite`.

**Testing:** `npm run ci:fmt`, `ci:lint`, and `ci:check` all pass. Installed in PI and confirmed that my denyWrite entries now take precedence.