### PR TITLE
fix: clean up bwrap mount point files after sandboxed commands

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -399,6 +399,9 @@ function createSandboxedBashOps(shellPath?: string): BashOperations {
           if (timeoutHandle) clearTimeout(timeoutHandle);
           signal?.removeEventListener("abort", onAbort);
 
+          // Clean up bwrap mount point files created on Linux
+          SandboxManager.cleanupAfterCommand();
+
           if (signal?.aborted) {
             reject(new Error("aborted"));
           } else if (timedOut) {


### PR DESCRIPTION
On Linux, bwrap creates zero-byte files as mount points for --ro-bind /dev/null when protecting non-existent deny paths (e.g. .bashrc, .gitconfig, .env). These persisted as ghostfiles because cleanupAfterCommand() was never called after sandboxed commands finished.