### PR TITLE
Enable Git-over-SSH on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Note below that the order of precedence for filesystem read and write are opposi
   "network": {
     "allowLocalBinding": true,     // ditto
     "allowAllUnixSockets": true,   // ditto
+    "allowUnauthenticatedSocksProxy": true, // Enables Git-over-SSH on macOS
     "allowedDomains": ["github.com", "*.github.com"],
     "deniedDomains": []
   },
@@ -138,6 +139,10 @@ files to check.
 allow all domains; pi-sandbox shows a warning when this is configured because it
 removes per-domain prompts and can be easy to add accidentally. `allowWrite` uses prefix
 matching, so `.` covers the entire current working directory.
+
+`allowUnauthenticatedSocksProxy` is enabled by default on macOS so Git-over-SSH
+works with the built-in `nc`. Domain filtering still applies, but another local process
+that discovers the temporary proxy port can use it while the sandbox is running.
 
 > **⚠️ Read and write have different precedence rules:**
 >

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@carderne/sandbox-runtime": "^0.0.66"
+        "@carderne/sandbox-runtime": "^0.0.67"
       },
       "devDependencies": {
         "@earendil-works/pi-coding-agent": "^0.80.0",
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@carderne/sandbox-runtime": {
-      "version": "0.0.66",
-      "resolved": "https://registry.npmjs.org/@carderne/sandbox-runtime/-/sandbox-runtime-0.0.66.tgz",
-      "integrity": "sha512-Q1tlewMvNhZE+DO+s3nYLavFyuMpvozVSBDrl069bJQn7Y2VsUI/Pl2lN7xKQwtXsqJMJGeu8+YAb75d8BB3mg==",
+      "version": "0.0.67",
+      "resolved": "https://registry.npmjs.org/@carderne/sandbox-runtime/-/sandbox-runtime-0.0.67.tgz",
+      "integrity": "sha512-H1pwD8FkfHwpdF87MKlY4gsvFJHhK0SmvE+pXNv/FjnudMD6So2icUg5cqnytquLUYBD5jVm61bRIBPeElp7Qg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@pondwader/socks5-server": "^1.0.10",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ci:test": "npm test"
   },
   "dependencies": {
-    "@carderne/sandbox-runtime": "^0.0.66"
+    "@carderne/sandbox-runtime": "^0.0.67"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "^0.80.0",

--- a/sandbox.json
+++ b/sandbox.json
@@ -3,6 +3,7 @@
   "allowBrowserProcess": true,
   "network": {
     "allowLocalBinding": true,
+    "allowUnauthenticatedSocksProxy": true,
     "allowAllUnixSockets": true,
     "allowedDomains": [
       "localhost",

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,13 +5,17 @@ import { dirname, join } from "node:path";
 import { type SandboxRuntimeConfig } from "@carderne/sandbox-runtime";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 
-export interface SandboxConfig extends SandboxRuntimeConfig {
+export type SandboxConfig = Omit<SandboxRuntimeConfig, "network"> & {
   enabled?: boolean;
-}
+  network?: NonNullable<SandboxRuntimeConfig["network"]> & {
+    allowUnauthenticatedSocksProxy?: boolean;
+  };
+};
 
 export const DEFAULT_CONFIG: SandboxConfig = {
   enabled: true,
   network: {
+    allowUnauthenticatedSocksProxy: process.platform === "darwin",
     allowedDomains: [
       "npmjs.org",
       "*.npmjs.org",

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -20,6 +20,7 @@ test("deepMerge merges sections while replacing configured arrays", () => {
   assert.equal(merged.enabled, false);
   assert.deepEqual(merged.network?.allowedDomains, ["example.com"]);
   assert.deepEqual(merged.network?.deniedDomains, []);
+  assert.equal(merged.network?.allowUnauthenticatedSocksProxy, process.platform === "darwin");
   assert.deepEqual(merged.filesystem?.allowWrite, ["/work"]);
   assert.deepEqual(merged.filesystem?.denyWrite, DEFAULT_CONFIG.filesystem?.denyWrite);
   assert.equal(merged.allowBrowserProcess, true);


### PR DESCRIPTION
## Summary

- enable `allowUnauthenticatedSocksProxy` in the built-in defaults
- include it in the example sandbox config
- document why it is needed and the local-process security trade-off

## Why

macOS's built-in `nc` cannot authenticate to a SOCKS5 proxy, so the runtime's injected Git SSH proxy command currently fails before connecting to GitHub.

This keeps domain filtering in place while allowing Git-over-SSH through the loopback SOCKS proxy. Another local process that discovers the ephemeral proxy port could use it while the sandbox is running.

Depends on carderne/sandbox-runtime#11. Before merging, `@carderne/sandbox-runtime` must be bumped to the release containing that PR.

## Tests

- `npm run ci:fmt`
- `npm run ci:lint`
- `npm run ci:check`
- `npm run ci:test`
