### PR TITLE
feat: compose sandbox configuration layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,10 @@ pi install npm:pi-sandbox
 
 #### Configure
 Add a config like this either to `~/.pi/agent/sandbox.json` (global) or to `.pi/sandbox.json` (local).
-Local config takes precedence over global.
+Scalar settings in the local config take precedence over global settings. The
+path and domain arrays from both files are combined and deduplicated, so a
+project can add permissions without repeating the global configuration. Built-in
+defaults are used for an array only when neither file configures it.
 
 Note below that the order of precedence for filesystem read and write are opposite.
 
@@ -78,13 +81,14 @@ Note below that the order of precedence for filesystem read and write are opposi
   },
   "filesystem": {
     // For READS:
-    // - ANY read is prompted unless the path is already in allowRead
+    // - ANY read is prompted unless the path is in allowRead or allowWrite
     // - Granting a prompt adds to allowRead, which overrides denyRead
     // - denyRead is not a hard-block; it just marks regions as denied by default
     "denyRead": ["/Users", "/home"],
     "allowRead": [".", "~/.config", "~/.local", "Library"],
 
     // For WRITES:
+    // - allowWrite also grants read access to the same paths
     // - empty ALLOW means no write access at all
     // - DENY takes precedence and is never prompted
     "allowWrite": [".", "/tmp"],
@@ -126,7 +130,7 @@ extension reloads or pi restarts.
 | Rule | Behaviour |
 |------|-----------|
 | Domain not in `allowedDomains` | Prompted (bash and `!cmd`) |
-| Path not in `allowRead` | Prompted (read tool); granting adds to `allowRead` |
+| Path not in `allowRead` or `allowWrite` | Prompted (read tool); granting adds to `allowRead` |
 | Path not in `allowWrite` | Prompted (write/edit tools and bash write failures) |
 | Path in `denyWrite` | Hard-blocked, no prompt |
 | Domain in `deniedDomains` | Hard-blocked at OS level, no prompt |
@@ -138,7 +142,8 @@ files to check.
 `allowedDomains` supports `*.example.com` wildcards. It also supports `"*"` to
 allow all domains; pi-sandbox shows a warning when this is configured because it
 removes per-domain prompts and can be easy to add accidentally. `allowWrite` uses prefix
-matching, so `.` covers the entire current working directory.
+matching, so `.` covers the entire current working directory. Write access also
+implies read access; paths do not need to be repeated in `allowRead`.
 
 `allowUnauthenticatedSocksProxy` is enabled by default on macOS so Git-over-SSH
 works with the built-in `nc`. Domain filtering still applies, but another local process
@@ -146,14 +151,16 @@ that discovers the temporary proxy port can use it while the sandbox is running.
 
 > **⚠️ Read and write have different precedence rules:**
 >
-> - **Read:** Every read is prompted unless the path is already in `allowRead`.
+> - **Read:** Every read is prompted unless the path is in `allowRead` or `allowWrite`.
 >   `denyRead` is not a hard-block — it marks regions as denied by default, but
 >   granting a prompt adds the path to `allowRead`, overriding `denyRead`.
 > - **Write:** `denyWrite` takes precedence over `allowWrite` and is never
 >   prompted. A path in `denyWrite` is always blocked, even if it matches
 >   `allowWrite`.
 
-If neither file exists, built-in defaults apply (see above for the defaults).
+If neither file configures an array, its built-in defaults apply (see above for
+the defaults). Once an array is configured, only its combined global and local
+entries are used, so an explicit empty array disables that default.
 
 The footer shows a lock indicator while the sandbox is active.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,14 @@ export type SandboxConfig = Omit<SandboxRuntimeConfig, "network"> & {
   };
 };
 
+type NetworkConfig = NonNullable<SandboxConfig["network"]>;
+type FilesystemConfig = NonNullable<SandboxConfig["filesystem"]>;
+
+export type SandboxConfigFile = Omit<Partial<SandboxConfig>, "network" | "filesystem"> & {
+  network?: Partial<NetworkConfig>;
+  filesystem?: Partial<FilesystemConfig>;
+};
+
 export const DEFAULT_CONFIG: SandboxConfig = {
   enabled: true,
   network: {
@@ -38,28 +46,106 @@ export const DEFAULT_CONFIG: SandboxConfig = {
   },
 };
 
-export function deepMerge(base: SandboxConfig, overrides: Partial<SandboxConfig>): SandboxConfig {
-  const result: SandboxConfig = { ...base };
-
-  if (overrides.enabled !== undefined) result.enabled = overrides.enabled;
-  if (overrides.network) result.network = { ...base.network, ...overrides.network };
-  if (overrides.filesystem) result.filesystem = { ...base.filesystem, ...overrides.filesystem };
-
-  if (overrides.ignoreViolations) result.ignoreViolations = overrides.ignoreViolations;
-  if (overrides.enableWeakerNestedSandbox !== undefined) {
-    result.enableWeakerNestedSandbox = overrides.enableWeakerNestedSandbox;
-  }
-  if (overrides.allowBrowserProcess !== undefined) {
-    result.allowBrowserProcess = overrides.allowBrowserProcess;
-  }
-
-  return result;
+function mergeObjects(base: SandboxConfig, overrides: SandboxConfigFile): SandboxConfig {
+  return {
+    ...base,
+    ...overrides,
+    network: overrides.network
+      ? ({ ...base.network, ...overrides.network } as NetworkConfig)
+      : base.network,
+    filesystem: overrides.filesystem
+      ? ({ ...base.filesystem, ...overrides.filesystem } as FilesystemConfig)
+      : base.filesystem,
+  };
 }
 
-function readJsonConfig(configPath: string, warn: boolean): Partial<SandboxConfig> {
+function stringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) return undefined;
+  return value;
+}
+
+function mergeConfiguredArray(
+  fallback: string[] | undefined,
+  globalValue: unknown,
+  projectValue: unknown,
+): string[] | undefined {
+  const globalEntries = stringArray(globalValue);
+  const projectEntries = stringArray(projectValue);
+  if (globalEntries === undefined && projectEntries === undefined) return fallback;
+  return [...new Set([...(globalEntries ?? []), ...(projectEntries ?? [])])];
+}
+
+export function mergeConfigLayers(
+  defaults: SandboxConfig,
+  globalConfig: SandboxConfigFile,
+  projectConfig: SandboxConfigFile,
+): SandboxConfig {
+  const merged = mergeObjects(mergeObjects(defaults, globalConfig), projectConfig);
+
+  return {
+    ...merged,
+    network: {
+      ...merged.network,
+      allowedDomains:
+        mergeConfiguredArray(
+          defaults.network?.allowedDomains,
+          globalConfig.network?.allowedDomains,
+          projectConfig.network?.allowedDomains,
+        ) ?? [],
+      deniedDomains:
+        mergeConfiguredArray(
+          defaults.network?.deniedDomains,
+          globalConfig.network?.deniedDomains,
+          projectConfig.network?.deniedDomains,
+        ) ?? [],
+      allowUnixSockets: mergeConfiguredArray(
+        defaults.network?.allowUnixSockets,
+        globalConfig.network?.allowUnixSockets,
+        projectConfig.network?.allowUnixSockets,
+      ),
+      allowMachLookup: mergeConfiguredArray(
+        defaults.network?.allowMachLookup,
+        globalConfig.network?.allowMachLookup,
+        projectConfig.network?.allowMachLookup,
+      ),
+    },
+    filesystem: {
+      ...merged.filesystem,
+      denyRead:
+        mergeConfiguredArray(
+          defaults.filesystem?.denyRead,
+          globalConfig.filesystem?.denyRead,
+          projectConfig.filesystem?.denyRead,
+        ) ?? [],
+      allowRead: mergeConfiguredArray(
+        defaults.filesystem?.allowRead,
+        globalConfig.filesystem?.allowRead,
+        projectConfig.filesystem?.allowRead,
+      ),
+      allowWrite:
+        mergeConfiguredArray(
+          defaults.filesystem?.allowWrite,
+          globalConfig.filesystem?.allowWrite,
+          projectConfig.filesystem?.allowWrite,
+        ) ?? [],
+      denyWrite:
+        mergeConfiguredArray(
+          defaults.filesystem?.denyWrite,
+          globalConfig.filesystem?.denyWrite,
+          projectConfig.filesystem?.denyWrite,
+        ) ?? [],
+    },
+  };
+}
+
+function readJsonConfig(configPath: string, warn: boolean): SandboxConfigFile {
   if (!existsSync(configPath)) return {};
   try {
-    return JSON.parse(readFileSync(configPath, "utf-8"));
+    const parsed: unknown = JSON.parse(readFileSync(configPath, "utf-8"));
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new Error("configuration must be a JSON object");
+    }
+    return parsed as SandboxConfigFile;
   } catch (error) {
     if (warn) console.error(`Warning: Could not parse ${configPath}: ${error}`);
     return {};
@@ -78,52 +164,46 @@ export function loadConfig(cwd: string): SandboxConfig {
   const globalConfigPath = join(getAgentDir(), "sandbox.json");
   const globalConfig = readJsonConfig(globalConfigPath, true);
   const projectConfig = readJsonConfig(projectConfigPath, true);
-  return deepMerge(deepMerge(DEFAULT_CONFIG, globalConfig), projectConfig);
+  return mergeConfigLayers(DEFAULT_CONFIG, globalConfig, projectConfig);
 }
 
-function writeConfigFile(configPath: string, config: Partial<SandboxConfig>): void {
+function writeConfigFile(configPath: string, config: SandboxConfigFile): void {
   mkdirSync(dirname(configPath), { recursive: true });
   writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
 }
 
 export function addDomainToConfig(configPath: string, domain: string): void {
   const config = readJsonConfig(configPath, false);
-  const existing = config.network?.allowedDomains ?? [];
+  const existing = stringArray(config.network?.allowedDomains) ?? [];
   if (existing.includes(domain)) return;
 
   config.network = {
     ...config.network,
     allowedDomains: [...existing, domain],
-    deniedDomains: config.network?.deniedDomains ?? [],
   };
   writeConfigFile(configPath, config);
 }
 
 export function addReadPathToConfig(configPath: string, pathToAdd: string): void {
   const config = readJsonConfig(configPath, false);
-  const existing = config.filesystem?.allowRead ?? [];
+  const existing = stringArray(config.filesystem?.allowRead) ?? [];
   if (existing.includes(pathToAdd)) return;
 
   config.filesystem = {
     ...config.filesystem,
     allowRead: [...existing, pathToAdd],
-    denyRead: config.filesystem?.denyRead ?? [],
-    allowWrite: config.filesystem?.allowWrite ?? [],
-    denyWrite: config.filesystem?.denyWrite ?? [],
   };
   writeConfigFile(configPath, config);
 }
 
 export function addWritePathToConfig(configPath: string, pathToAdd: string): void {
   const config = readJsonConfig(configPath, false);
-  const existing = config.filesystem?.allowWrite ?? [];
+  const existing = stringArray(config.filesystem?.allowWrite) ?? [];
   if (existing.includes(pathToAdd)) return;
 
   config.filesystem = {
     ...config.filesystem,
     allowWrite: [...existing, pathToAdd],
-    denyRead: config.filesystem?.denyRead ?? [],
-    denyWrite: config.filesystem?.denyWrite ?? [],
   };
   writeConfigFile(configPath, config);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,7 @@ import {
   extractBlockedWritePath,
   initializeSandbox,
   reinitializeSandbox,
+  resolveAllowances,
   type SessionAllowances,
   supportsNodeEnvProxy,
 } from "./sandbox-runtime.ts";
@@ -53,18 +54,10 @@ export default function (pi: ExtensionAPI) {
   let sandboxInitialized = false;
   const allowances: SessionAllowances = { domains: [], readPaths: [], writePaths: [] };
 
-  const effectiveDomains = (cwd: string) => [
-    ...(loadConfig(cwd).network?.allowedDomains ?? []),
-    ...allowances.domains,
-  ];
-  const effectiveReadPaths = (cwd: string) => [
-    ...(loadConfig(cwd).filesystem?.allowRead ?? []),
-    ...allowances.readPaths,
-  ];
-  const effectiveWritePaths = (cwd: string) => [
-    ...(loadConfig(cwd).filesystem?.allowWrite ?? []),
-    ...allowances.writePaths,
-  ];
+  const effectiveAllowances = (cwd: string) => resolveAllowances(loadConfig(cwd), allowances);
+  const effectiveDomains = (cwd: string) => effectiveAllowances(cwd).domains;
+  const effectiveReadPaths = (cwd: string) => effectiveAllowances(cwd).readPaths;
+  const effectiveWritePaths = (cwd: string) => effectiveAllowances(cwd).writePaths;
 
   async function refreshSandbox(cwd: string): Promise<void> {
     if (!sandboxInitialized) return;
@@ -116,7 +109,7 @@ export default function (pi: ExtensionAPI) {
     }
 
     try {
-      await initializeSandbox(config);
+      await initializeSandbox(config, allowances);
       if (setProxyEnvironment && supportsNodeEnvProxy(process.versions.node)) {
         process.env.NODE_USE_ENV_PROXY ??= "1";
       }

--- a/src/sandbox-runtime.ts
+++ b/src/sandbox-runtime.ts
@@ -17,6 +17,36 @@ export interface SessionAllowances {
   writePaths: string[];
 }
 
+export interface EffectiveAllowances {
+  domains: string[];
+  readPaths: string[];
+  writePaths: string[];
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+export function resolveAllowances(
+  config: SandboxConfig,
+  allowances?: SessionAllowances,
+): EffectiveAllowances {
+  const writePaths = unique([
+    ...(config.filesystem?.allowWrite ?? []),
+    ...(allowances?.writePaths ?? []),
+  ]);
+
+  return {
+    domains: unique([...(config.network?.allowedDomains ?? []), ...(allowances?.domains ?? [])]),
+    readPaths: unique([
+      ...(config.filesystem?.allowRead ?? []),
+      ...(allowances?.readPaths ?? []),
+      ...writePaths,
+    ]),
+    writePaths,
+  };
+}
+
 export function createNetworkAskCallback(allowedDomains: string[]): SandboxAskCallback {
   return async ({ host }) => domainIsAllowed(host, allowedDomains);
 }
@@ -25,17 +55,19 @@ export function buildRuntimeConfig(
   config: SandboxConfig,
   allowances?: SessionAllowances,
 ): SandboxRuntimeConfig {
+  const effective = resolveAllowances(config, allowances);
+
   return {
     network: {
       ...config.network,
-      allowedDomains: [...(config.network?.allowedDomains ?? []), ...(allowances?.domains ?? [])],
+      allowedDomains: effective.domains,
       deniedDomains: config.network?.deniedDomains ?? [],
     },
     filesystem: {
       ...config.filesystem,
       denyRead: config.filesystem?.denyRead ?? [],
-      allowRead: [...(config.filesystem?.allowRead ?? []), ...(allowances?.readPaths ?? [])],
-      allowWrite: [...(config.filesystem?.allowWrite ?? []), ...(allowances?.writePaths ?? [])],
+      allowRead: effective.readPaths,
+      allowWrite: effective.writePaths,
       denyWrite: config.filesystem?.denyWrite ?? [],
     },
     ignoreViolations: config.ignoreViolations,

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -169,7 +169,8 @@ export function formatSandboxConfiguration(
       ? [`  Session write: ${allowances.writePaths.join(", ")}`]
       : []),
     "",
-    "Note: ALL reads are prompted unless the path is already in allowRead.",
+    "Note: ALL reads are prompted unless the path is in allowRead or allowWrite.",
+    "Note: allowWrite also grants read access to the same path.",
     "Note: denyRead is not a hard-block — granting a prompt adds to allowRead, overriding denyRead.",
     "Note: denyWrite takes PRECEDENCE over allowWrite and is never prompted.",
   ].join("\n");

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,47 +1,103 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
 import assert from "node:assert/strict";
 
-import { deepMerge, DEFAULT_CONFIG } from "../src/config.ts";
+import {
+  addDomainToConfig,
+  addReadPathToConfig,
+  addWritePathToConfig,
+  DEFAULT_CONFIG,
+  mergeConfigLayers,
+} from "../src/config.ts";
 
-test("deepMerge merges sections while replacing configured arrays", () => {
-  const merged = deepMerge(DEFAULT_CONFIG, {
-    enabled: false,
-    network: { allowedDomains: ["example.com"], deniedDomains: [] },
-    filesystem: {
-      denyRead: DEFAULT_CONFIG.filesystem?.denyRead ?? [],
-      allowRead: DEFAULT_CONFIG.filesystem?.allowRead,
-      allowWrite: ["/work"],
-      denyWrite: DEFAULT_CONFIG.filesystem?.denyWrite ?? [],
+test("mergeConfigLayers combines configured arrays and deduplicates entries", () => {
+  const merged = mergeConfigLayers(
+    DEFAULT_CONFIG,
+    {
+      network: {
+        allowedDomains: ["global.example.com", "shared.example.com"],
+        deniedDomains: ["blocked.example.com"],
+        allowUnixSockets: ["/global.sock"],
+      },
+      filesystem: {
+        allowRead: ["/global", "/shared"],
+        denyWrite: ["global.key"],
+      },
     },
-    allowBrowserProcess: true,
-  });
+    {
+      network: {
+        allowedDomains: ["project.example.com", "shared.example.com"],
+        deniedDomains: ["project-blocked.example.com"],
+        allowUnixSockets: ["/project.sock"],
+      },
+      filesystem: {
+        allowRead: ["/project", "/shared"],
+        denyWrite: ["project.key"],
+      },
+    },
+  );
 
-  assert.equal(merged.enabled, false);
-  assert.deepEqual(merged.network?.allowedDomains, ["example.com"]);
-  assert.deepEqual(merged.network?.deniedDomains, []);
-  assert.equal(merged.network?.allowUnauthenticatedSocksProxy, process.platform === "darwin");
-  assert.deepEqual(merged.filesystem?.allowWrite, ["/work"]);
-  assert.deepEqual(merged.filesystem?.denyWrite, DEFAULT_CONFIG.filesystem?.denyWrite);
-  assert.equal(merged.allowBrowserProcess, true);
+  assert.deepEqual(merged.network?.allowedDomains, [
+    "global.example.com",
+    "shared.example.com",
+    "project.example.com",
+  ]);
+  assert.deepEqual(merged.network?.deniedDomains, [
+    "blocked.example.com",
+    "project-blocked.example.com",
+  ]);
+  assert.deepEqual(merged.network?.allowUnixSockets, ["/global.sock", "/project.sock"]);
+  assert.deepEqual(merged.filesystem?.allowRead, ["/global", "/shared", "/project"]);
+  assert.deepEqual(merged.filesystem?.denyWrite, ["global.key", "project.key"]);
 });
 
-test("a later merge takes precedence over global configuration", () => {
-  const global = deepMerge(DEFAULT_CONFIG, {
+test("mergeConfigLayers ignores malformed permission arrays", () => {
+  const merged = mergeConfigLayers(
+    DEFAULT_CONFIG,
+    { filesystem: { denyWrite: "*.key" as unknown as string[] } },
+    {},
+  );
+
+  assert.deepEqual(merged.filesystem?.denyWrite, DEFAULT_CONFIG.filesystem?.denyWrite);
+});
+
+test("mergeConfigLayers uses defaults only for arrays not configured by either file", () => {
+  const merged = mergeConfigLayers(
+    DEFAULT_CONFIG,
+    {
+      enabled: false,
+      filesystem: { allowWrite: [] },
+    },
+    {
+      enabled: true,
+      allowBrowserProcess: true,
+    },
+  );
+
+  assert.equal(merged.enabled, true);
+  assert.equal(merged.allowBrowserProcess, true);
+  assert.deepEqual(merged.filesystem?.allowWrite, []);
+  assert.deepEqual(merged.filesystem?.allowRead, DEFAULT_CONFIG.filesystem?.allowRead);
+  assert.deepEqual(merged.network?.allowedDomains, DEFAULT_CONFIG.network?.allowedDomains);
+});
+
+test("permission writers only persist the property being changed", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-sandbox-config-"));
+  const configPath = join(root, "sandbox.json");
+
+  addReadPathToConfig(configPath, "/read");
+  addWritePathToConfig(configPath, "/write");
+  addDomainToConfig(configPath, "example.com");
+
+  const written = JSON.parse(readFileSync(configPath, "utf8"));
+  assert.deepEqual(written, {
+    network: { allowedDomains: ["example.com"] },
     filesystem: {
-      denyRead: [],
-      allowRead: ["/global"],
-      allowWrite: [],
-      denyWrite: [],
+      allowRead: ["/read"],
+      allowWrite: ["/write"],
     },
   });
-  const project = deepMerge(global, {
-    filesystem: {
-      denyRead: [],
-      allowRead: ["/project"],
-      allowWrite: [],
-      denyWrite: [],
-    },
-  });
-  assert.deepEqual(project.filesystem?.allowRead, ["/project"]);
 });

--- a/test/sandbox-runtime.test.ts
+++ b/test/sandbox-runtime.test.ts
@@ -6,6 +6,7 @@ import { DEFAULT_CONFIG } from "../src/config.ts";
 import {
   buildRuntimeConfig,
   extractBlockedWritePath,
+  resolveAllowances,
   supportsNodeEnvProxy,
 } from "../src/sandbox-runtime.ts";
 
@@ -17,8 +18,28 @@ test("buildRuntimeConfig adds session allowances without mutating config", () =>
   });
   assert.equal(runtime.network?.allowedDomains?.includes("example.com"), true);
   assert.equal(runtime.filesystem?.allowRead?.includes("/read"), true);
+  assert.equal(runtime.filesystem?.allowRead?.includes("/write"), true);
   assert.equal(runtime.filesystem?.allowWrite?.includes("/write"), true);
   assert.equal(DEFAULT_CONFIG.network?.allowedDomains?.includes("example.com"), false);
+});
+
+test("resolveAllowances makes configured and session write paths readable", () => {
+  const config = {
+    ...DEFAULT_CONFIG,
+    filesystem: {
+      ...DEFAULT_CONFIG.filesystem!,
+      allowRead: [],
+      allowWrite: ["/configured-write"],
+    },
+  };
+  const effective = resolveAllowances(config, {
+    domains: [],
+    readPaths: [],
+    writePaths: ["/session-write"],
+  });
+
+  assert.deepEqual(effective.readPaths, ["/configured-write", "/session-write"]);
+  assert.deepEqual(effective.writePaths, ["/configured-write", "/session-write"]);
 });
 
 test("extractBlockedWritePath recognizes shell sandbox errors", () => {


### PR DESCRIPTION
## Summary

Global and project sandbox configs now compose their path and domain permission lists, so project-specific entries no longer replace global ones. Writable paths are also readable, preventing a second prompt when an operation reads a path it can already modify.

Closes #11.

## Design

Permission arrays are concatenated and deduplicated across user config layers. Built-in arrays remain fallbacks when neither file configures a field, preserving explicit empty arrays as a way to disable defaults. Project scalar values continue to override global values.

A shared allowance resolver feeds both direct tool checks and `@carderne/sandbox-runtime`. Persisted prompt choices now update only the selected raw property rather than filling unrelated arrays.
