### PR TITLE
feature: command for adding paths to allow lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Note below that the order of precedence for filesystem read and write are opposi
 ```
 pi --no-sandbox          disable sandboxing for the session
 /sandbox                 show current configuration and session allowances
+/sandbox-enable          enable the sandbox for this session
+/sandbox-disable         disable the sandbox for this session
 ```
 
 ## What it does

--- a/README.md
+++ b/README.md
@@ -100,10 +100,13 @@ Note below that the order of precedence for filesystem read and write are opposi
 #### Usage
 
 ```
-pi --no-sandbox          disable sandboxing for the session
-/sandbox                 show current configuration and session allowances
-/sandbox-enable          enable the sandbox for this session
-/sandbox-disable         disable the sandbox for this session
+pi --no-sandbox                  disable sandboxing for the session
+/sandbox                         show current configuration and session allowances
+/sandbox-enable                  enable the sandbox for this session
+/sandbox-disable                 disable the sandbox for this session
+/sandbox-allow domain <url>      prompt to add a domain to allowedDomains
+/sandbox-allow read <path>       prompt to add a path to allowRead
+/sandbox-allow write <path>      prompt to add a path to allowWrite
 ```
 
 ## What it does

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,7 @@ import {
   type PermissionChoice,
   promptDomainBlock,
   promptReadBlock,
+  showPermissionPrompt,
   promptWriteBlock,
   warnIfAllDomainsAllowed,
 } from "./ui.ts";
@@ -330,6 +331,31 @@ export default function (pi: ExtensionAPI) {
       sandboxInitialized = false;
       ctx.ui.setStatus("sandbox", "");
       ctx.ui.notify("Sandbox disabled", "info");
+    },
+  });
+
+  pi.registerCommand("sandbox-allow", {
+    description: "Prompt to allow a domain or read/write access to a file path",
+    handler: async (args, ctx) => {
+      const [kind, ...targetParts] = args.trim().split(/\s+/);
+      const targetArg = targetParts.join(" ");
+
+      if ((kind !== "domain" && kind !== "read" && kind !== "write") || !targetArg) {
+        ctx.ui.notify("Usage: /sandbox-allow <domain|read|write> <domain-or-path>", "error");
+        return;
+      }
+
+      const target = kind === "domain" ? targetArg : canonicalizePath(targetArg);
+      const configKey =
+        kind === "domain" ? "allowedDomains" : kind === "read" ? "allowRead" : "allowWrite";
+      const choice = await showPermissionPrompt(ctx, `Add ${target} to ${configKey}?`);
+      if (choice === "abort") {
+        ctx.ui.notify("Allow cancelled", "info");
+        return;
+      }
+
+      await applyChoice(choice, kind, target, ctx.cwd);
+      ctx.ui.notify(`Added ${target} to ${configKey}`, "info");
     },
   });
 


### PR DESCRIPTION
Adds a new `/allow` slash command for adding filesystem paths to the sandbox allow lists.

```
/allow read <path>
/allow write <path>
```

My main reason for wanting this feature is not because it's so hard to edit the settings file, but this: When a need arises to work in a directory other than the current one, with the current context, this can result in large numbers of requests for access to various files, and executables failing due to lack of directory access. This leads to blindly accepting the allowlist prompts, and no way to fix the failing executables. My main interest is adding to the session allow list which otherwise seems to be impossible. The new command shows the usual permission prompt with options to add to session, project, or global settings, or abort.

The change is quite small and only adds a ui command which brings together existing internal functions.

### Details

- Reuses the existing showPermissionPrompt UI so /allow has the same behavior as standard sandbox prompts.
- Reuses existing applyChoice machinery so session/project/global allow choices are handled consistently.
- Rejects invalid invocations.
- Updates README usage documentation.

