### PR TITLE
feat: emit attention event for sandbox prompts

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -169,7 +169,7 @@ export default function (pi: ExtensionAPI) {
         const blockedPath = extractBlockedWritePath(output);
 
         if (blockedPath) {
-          const choice = await promptWriteBlock(ctx, blockedPath);
+          const choice = await promptWriteBlock(pi, ctx, blockedPath);
           if (choice.action !== "abort") {
             await applyChoice(choice.action, "write", choice.value, ctx.cwd);
             const config = loadConfig(ctx.cwd);
@@ -204,7 +204,7 @@ export default function (pi: ExtensionAPI) {
 
     for (const domain of extractDomainsFromCommand(event.command)) {
       if (!domainIsAllowed(domain, effectiveDomains(ctx.cwd))) {
-        const choice = await promptDomainBlock(ctx, domain);
+        const choice = await promptDomainBlock(pi, ctx, domain);
         if (choice.action === "abort") {
           return {
             result: {
@@ -230,7 +230,7 @@ export default function (pi: ExtensionAPI) {
     if (sandboxInitialized && isToolCallEventType("bash", event)) {
       for (const domain of extractDomainsFromCommand(event.input.command)) {
         if (!domainIsAllowed(domain, effectiveDomains(ctx.cwd))) {
-          const choice = await promptDomainBlock(ctx, domain);
+          const choice = await promptDomainBlock(pi, ctx, domain);
           if (choice.action === "abort") {
             return {
               block: true,
@@ -245,7 +245,7 @@ export default function (pi: ExtensionAPI) {
     if (isToolCallEventType("read", event)) {
       const path = canonicalizePath(event.input.path);
       if (!matchesPattern(path, effectiveReadPaths(ctx.cwd))) {
-        const choice = await promptReadBlock(ctx, path);
+        const choice = await promptReadBlock(pi, ctx, path);
         if (choice.action === "abort") {
           return { block: true, reason: `Sandbox: read access denied for "${path}"` };
         }
@@ -266,7 +266,7 @@ export default function (pi: ExtensionAPI) {
         };
       }
       if (shouldPromptForWrite(path, effectiveWritePaths(ctx.cwd), matchesPattern)) {
-        const choice = await promptWriteBlock(ctx, path);
+        const choice = await promptWriteBlock(pi, ctx, path);
         if (choice.action === "abort") {
           return {
             block: true,
@@ -349,6 +349,7 @@ export default function (pi: ExtensionAPI) {
       const configKey =
         kind === "domain" ? "allowedDomains" : kind === "read" ? "allowRead" : "allowWrite";
       const choice = await showPermissionPrompt(
+        pi,
         ctx,
         `Add ${target} to ${configKey}?`,
         target,

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,4 +1,4 @@
-import { type ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Input, Key, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 
 import { type SandboxConfig } from "./config.ts";
@@ -40,12 +40,15 @@ const PERMISSION_OPTIONS: PromptOption[] = [
 ];
 
 export async function showPermissionPrompt(
+  pi: ExtensionAPI,
   ctx: ExtensionContext,
   title: string,
   originalValue: string,
   validateValue: (value: string) => string | null,
 ): Promise<PermissionPromptResult> {
   if (!ctx.hasUI) return { action: "abort", value: originalValue };
+
+  pi.events.emit("request-attention", { message: "Sandbox permission required" });
 
   const result = await ctx.ui.custom<PermissionPromptResult>((tui, theme, _kb, done) => {
     const input = new Input();
@@ -223,10 +226,12 @@ const validRule = (value: string, matches: boolean, target: string): string | nu
 };
 
 export function promptDomainBlock(
+  pi: ExtensionAPI,
   ctx: ExtensionContext,
   domain: string,
 ): Promise<PermissionPromptResult> {
   return showPermissionPrompt(
+    pi,
     ctx,
     `🌐 Network blocked: "${domain}" is not in allowedDomains`,
     domain,
@@ -235,10 +240,12 @@ export function promptDomainBlock(
 }
 
 export function promptReadBlock(
+  pi: ExtensionAPI,
   ctx: ExtensionContext,
   path: string,
 ): Promise<PermissionPromptResult> {
   return showPermissionPrompt(
+    pi,
     ctx,
     `📖 Read blocked: "${path}" is not in allowRead`,
     path,
@@ -247,10 +254,12 @@ export function promptReadBlock(
 }
 
 export function promptWriteBlock(
+  pi: ExtensionAPI,
   ctx: ExtensionContext,
   path: string,
 ): Promise<PermissionPromptResult> {
   return showPermissionPrompt(
+    pi,
     ctx,
     `📝 Write blocked: "${path}" is not in allowWrite`,
     path,


### PR DESCRIPTION
## Summary

Sandbox permission prompts now emit a `request-attention` event before they open. Other Pi extensions can use it to notify users when a blocked domain or path needs a decision.

## Design

The event is emitted only when an interactive prompt can be shown. Notification delivery remains the responsibility of subscribing extensions.