### PR TITLE
feat: add timeout for interactive permission prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Note below that the order of precedence for filesystem read and write are opposi
 ```json
 {
   "enabled": true,
-  "permissionPromptTimeoutSeconds": 0, // Positive values auto-abort; 0 waits indefinitely
+  "permissionPromptTimeoutSeconds": 600, // Defaults to 10 minutes; 0 waits indefinitely
   "allowBrowserProcess": true,     // If you want to use agent-browser or similar Chrome setup
   "network": {
     "allowLocalBinding": true,     // ditto
@@ -120,10 +120,10 @@ checked against the same filesystem policy. The OS-level sandbox cannot cover
 these tools because they run directly in the Node.js process rather than in a
 subprocess.
 
-When a block is triggered, a prompt appears with four options. Set
-`permissionPromptTimeoutSeconds` to a positive number to automatically select
-**Abort (keep blocked)** when that many seconds elapse. Omit it or set it to `0`
-to wait indefinitely. A timeout never grants permission.
+When a block is triggered, a prompt appears with four options. Permission prompts
+automatically select **Abort (keep blocked)** after 10 minutes by default. Set
+`permissionPromptTimeoutSeconds` to a positive number to use a different timeout,
+or set it to `0` to wait indefinitely. A timeout never grants permission.
 
 - Abort (keep blocked)
 - Allow for this session only

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Note below that the order of precedence for filesystem read and write are opposi
 ```json
 {
   "enabled": true,
+  "permissionPromptTimeoutSeconds": 0, // Positive values auto-abort; 0 waits indefinitely
   "allowBrowserProcess": true,     // If you want to use agent-browser or similar Chrome setup
   "network": {
     "allowLocalBinding": true,     // ditto
@@ -119,7 +120,10 @@ checked against the same filesystem policy. The OS-level sandbox cannot cover
 these tools because they run directly in the Node.js process rather than in a
 subprocess.
 
-When a block is triggered, a prompt appears with four options:
+When a block is triggered, a prompt appears with four options. Set
+`permissionPromptTimeoutSeconds` to a positive number to automatically select
+**Abort (keep blocked)** when that many seconds elapse. Omit it or set it to `0`
+to wait indefinitely. A timeout never grants permission.
 
 - Abort (keep blocked)
 - Allow for this session only

--- a/sandbox.json
+++ b/sandbox.json
@@ -1,6 +1,6 @@
 {
   "enabled": true,
-  "permissionPromptTimeoutSeconds": 0,
+  "permissionPromptTimeoutSeconds": 600,
   "allowBrowserProcess": true,
   "network": {
     "allowLocalBinding": true,

--- a/sandbox.json
+++ b/sandbox.json
@@ -1,5 +1,6 @@
 {
   "enabled": true,
+  "permissionPromptTimeoutSeconds": 0,
   "allowBrowserProcess": true,
   "network": {
     "allowLocalBinding": true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,8 +21,11 @@ export type SandboxConfigFile = Omit<Partial<SandboxConfig>, "network" | "filesy
   filesystem?: Partial<FilesystemConfig>;
 };
 
+export const DEFAULT_PERMISSION_PROMPT_TIMEOUT_SECONDS = 10 * 60;
+
 export const DEFAULT_CONFIG: SandboxConfig = {
   enabled: true,
+  permissionPromptTimeoutSeconds: DEFAULT_PERMISSION_PROMPT_TIMEOUT_SECONDS,
   network: {
     allowUnauthenticatedSocksProxy: process.platform === "darwin",
     allowedDomains: [

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ import { getAgentDir } from "@earendil-works/pi-coding-agent";
 
 export type SandboxConfig = Omit<SandboxRuntimeConfig, "network"> & {
   enabled?: boolean;
+  permissionPromptTimeoutSeconds?: number;
   network?: NonNullable<SandboxRuntimeConfig["network"]> & {
     allowUnauthenticatedSocksProxy?: boolean;
   };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -169,7 +169,12 @@ export default function (pi: ExtensionAPI) {
         const blockedPath = extractBlockedWritePath(output);
 
         if (blockedPath) {
-          const choice = await promptWriteBlock(pi, ctx, blockedPath);
+          const choice = await promptWriteBlock(
+            pi,
+            ctx,
+            blockedPath,
+            loadConfig(ctx.cwd).permissionPromptTimeoutSeconds,
+          );
           if (choice.action !== "abort") {
             await applyChoice(choice.action, "write", choice.value, ctx.cwd);
             const config = loadConfig(ctx.cwd);
@@ -202,9 +207,15 @@ export default function (pi: ExtensionAPI) {
   pi.on("user_bash", async (event, ctx) => {
     if (!sandboxEnabled || !sandboxInitialized) return;
 
+    const config = loadConfig(ctx.cwd);
     for (const domain of extractDomainsFromCommand(event.command)) {
       if (!domainIsAllowed(domain, effectiveDomains(ctx.cwd))) {
-        const choice = await promptDomainBlock(pi, ctx, domain);
+        const choice = await promptDomainBlock(
+          pi,
+          ctx,
+          domain,
+          config.permissionPromptTimeoutSeconds,
+        );
         if (choice.action === "abort") {
           return {
             result: {
@@ -230,7 +241,12 @@ export default function (pi: ExtensionAPI) {
     if (sandboxInitialized && isToolCallEventType("bash", event)) {
       for (const domain of extractDomainsFromCommand(event.input.command)) {
         if (!domainIsAllowed(domain, effectiveDomains(ctx.cwd))) {
-          const choice = await promptDomainBlock(pi, ctx, domain);
+          const choice = await promptDomainBlock(
+            pi,
+            ctx,
+            domain,
+            config.permissionPromptTimeoutSeconds,
+          );
           if (choice.action === "abort") {
             return {
               block: true,
@@ -245,7 +261,7 @@ export default function (pi: ExtensionAPI) {
     if (isToolCallEventType("read", event)) {
       const path = canonicalizePath(event.input.path);
       if (!matchesPattern(path, effectiveReadPaths(ctx.cwd))) {
-        const choice = await promptReadBlock(pi, ctx, path);
+        const choice = await promptReadBlock(pi, ctx, path, config.permissionPromptTimeoutSeconds);
         if (choice.action === "abort") {
           return { block: true, reason: `Sandbox: read access denied for "${path}"` };
         }
@@ -266,7 +282,7 @@ export default function (pi: ExtensionAPI) {
         };
       }
       if (shouldPromptForWrite(path, effectiveWritePaths(ctx.cwd), matchesPattern)) {
-        const choice = await promptWriteBlock(pi, ctx, path);
+        const choice = await promptWriteBlock(pi, ctx, path, config.permissionPromptTimeoutSeconds);
         if (choice.action === "abort") {
           return {
             block: true,
@@ -346,6 +362,7 @@ export default function (pi: ExtensionAPI) {
       }
 
       const target = kind === "domain" ? targetArg : canonicalizePath(targetArg);
+      const config = loadConfig(ctx.cwd);
       const configKey =
         kind === "domain" ? "allowedDomains" : kind === "read" ? "allowRead" : "allowWrite";
       const choice = await showPermissionPrompt(
@@ -359,6 +376,7 @@ export default function (pi: ExtensionAPI) {
             kind === "domain" ? domainIsAllowed(target, [value]) : matchesPattern(target, [value]);
           return matches ? null : `Rule must match "${target}".`;
         },
+        config.permissionPromptTimeoutSeconds,
       );
       if (choice.action === "abort") {
         ctx.ui.notify("Allow cancelled", "info");

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -20,6 +20,19 @@ interface PromptOption {
   hint?: string;
 }
 
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+export function permissionPromptTimeoutMs(timeoutSeconds: unknown): number | undefined {
+  if (
+    typeof timeoutSeconds !== "number" ||
+    !Number.isFinite(timeoutSeconds) ||
+    timeoutSeconds <= 0
+  ) {
+    return undefined;
+  }
+  return Math.min(timeoutSeconds * 1000, MAX_TIMER_DELAY_MS);
+}
+
 const PERMISSION_OPTIONS: PromptOption[] = [
   { label: "Allow for this session only", key: "s", action: "session" },
   { label: "Abort (keep blocked)", key: "esc", action: "abort" },
@@ -45,11 +58,13 @@ export async function showPermissionPrompt(
   title: string,
   originalValue: string,
   validateValue: (value: string) => string | null,
+  timeoutSeconds?: number,
 ): Promise<PermissionPromptResult> {
   if (!ctx.hasUI) return { action: "abort", value: originalValue };
 
   pi.events.emit("request-attention", { message: "Sandbox permission required" });
 
+  const timeoutMs = permissionPromptTimeoutMs(timeoutSeconds);
   const result = await ctx.ui.custom<PermissionPromptResult>((tui, theme, _kb, done) => {
     const input = new Input();
     let selectedIndex = 0;
@@ -57,6 +72,20 @@ export async function showPermissionPrompt(
     let editing = false;
     let componentFocused = false;
     let error: string | null = null;
+    let resolved = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const clearPromptTimeout = (): void => {
+      if (timeout === undefined) return;
+      clearTimeout(timeout);
+      timeout = undefined;
+    };
+    const finish = (result: PermissionPromptResult): void => {
+      if (resolved) return;
+      resolved = true;
+      clearPromptTimeout();
+      done(result);
+    };
 
     const selectedOption = (): PromptOption =>
       PERMISSION_OPTIONS[selectedIndex] ?? PERMISSION_OPTIONS[0]!;
@@ -79,7 +108,7 @@ export async function showPermissionPrompt(
     };
     const resolve = (action: PermissionChoice): void => {
       if (action === "abort") {
-        done({ action, value: originalValue });
+        finish({ action, value: originalValue });
         return;
       }
 
@@ -92,8 +121,12 @@ export async function showPermissionPrompt(
         tui.requestRender();
         return;
       }
-      done({ action, value });
+      finish({ action, value });
     };
+
+    if (timeoutMs !== undefined) {
+      timeout = setTimeout(() => resolve("abort"), timeoutMs);
+    }
 
     return {
       get focused(): boolean {
@@ -214,6 +247,9 @@ export async function showPermissionPrompt(
       invalidate(): void {
         input.invalidate();
       },
+      dispose(): void {
+        clearPromptTimeout();
+      },
     };
   });
 
@@ -229,6 +265,7 @@ export function promptDomainBlock(
   pi: ExtensionAPI,
   ctx: ExtensionContext,
   domain: string,
+  timeoutSeconds?: number,
 ): Promise<PermissionPromptResult> {
   return showPermissionPrompt(
     pi,
@@ -236,6 +273,7 @@ export function promptDomainBlock(
     `🌐 Network blocked: "${domain}" is not in allowedDomains`,
     domain,
     (value) => validRule(value, domainIsAllowed(domain, [value]), `domain "${domain}"`),
+    timeoutSeconds,
   );
 }
 
@@ -243,6 +281,7 @@ export function promptReadBlock(
   pi: ExtensionAPI,
   ctx: ExtensionContext,
   path: string,
+  timeoutSeconds?: number,
 ): Promise<PermissionPromptResult> {
   return showPermissionPrompt(
     pi,
@@ -250,6 +289,7 @@ export function promptReadBlock(
     `📖 Read blocked: "${path}" is not in allowRead`,
     path,
     (value) => validRule(value, matchesPattern(path, [value]), `path "${path}"`),
+    timeoutSeconds,
   );
 }
 
@@ -257,6 +297,7 @@ export function promptWriteBlock(
   pi: ExtensionAPI,
   ctx: ExtensionContext,
   path: string,
+  timeoutSeconds?: number,
 ): Promise<PermissionPromptResult> {
   return showPermissionPrompt(
     pi,
@@ -264,6 +305,7 @@ export function promptWriteBlock(
     `📝 Write blocked: "${path}" is not in allowWrite`,
     path,
     (value) => validRule(value, matchesPattern(path, [value]), `path "${path}"`),
+    timeoutSeconds,
   );
 }
 

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -33,6 +33,10 @@ export function permissionPromptTimeoutMs(timeoutSeconds: unknown): number | und
   return Math.min(timeoutSeconds * 1000, MAX_TIMER_DELAY_MS);
 }
 
+export function permissionPromptRemainingSeconds(deadlineMs: number, nowMs = Date.now()): number {
+  return Math.max(0, Math.ceil((deadlineMs - nowMs) / 1000));
+}
+
 const PERMISSION_OPTIONS: PromptOption[] = [
   { label: "Allow for this session only", key: "s", action: "session" },
   { label: "Abort (keep blocked)", key: "esc", action: "abort" },
@@ -73,17 +77,24 @@ export async function showPermissionPrompt(
     let componentFocused = false;
     let error: string | null = null;
     let resolved = false;
+    let remainingSeconds: number | undefined;
     let timeout: ReturnType<typeof setTimeout> | undefined;
+    let countdown: ReturnType<typeof setInterval> | undefined;
 
-    const clearPromptTimeout = (): void => {
-      if (timeout === undefined) return;
-      clearTimeout(timeout);
-      timeout = undefined;
+    const clearPromptTimers = (): void => {
+      if (timeout !== undefined) {
+        clearTimeout(timeout);
+        timeout = undefined;
+      }
+      if (countdown !== undefined) {
+        clearInterval(countdown);
+        countdown = undefined;
+      }
     };
     const finish = (result: PermissionPromptResult): void => {
       if (resolved) return;
       resolved = true;
-      clearPromptTimeout();
+      clearPromptTimers();
       done(result);
     };
 
@@ -125,7 +136,18 @@ export async function showPermissionPrompt(
     };
 
     if (timeoutMs !== undefined) {
+      const deadlineMs = Date.now() + timeoutMs;
+      remainingSeconds = permissionPromptRemainingSeconds(deadlineMs);
       timeout = setTimeout(() => resolve("abort"), timeoutMs);
+      countdown = setInterval(
+        () => {
+          const nextRemainingSeconds = permissionPromptRemainingSeconds(deadlineMs);
+          if (nextRemainingSeconds === remainingSeconds) return;
+          remainingSeconds = nextRemainingSeconds;
+          tui.requestRender();
+        },
+        Math.min(1000, timeoutMs),
+      );
     }
 
     return {
@@ -137,7 +159,19 @@ export async function showPermissionPrompt(
         updateFocus();
       },
       render(width: number): string[] {
-        const lines = [truncateToWidth(theme.fg("warning", title), width), ""];
+        const lines = [truncateToWidth(theme.fg("warning", title), width)];
+        if (remainingSeconds !== undefined) {
+          lines.push(
+            truncateToWidth(
+              theme.fg(
+                "warning",
+                `⏳ Auto-abort in ${remainingSeconds}s (permission stays blocked)`,
+              ),
+              width,
+            ),
+          );
+        }
+        lines.push("");
         for (let i = 0; i < PERMISSION_OPTIONS.length; i++) {
           const option = PERMISSION_OPTIONS[i]!;
           const isSelected = i === selectedIndex;
@@ -248,7 +282,7 @@ export async function showPermissionPrompt(
         input.invalidate();
       },
       dispose(): void {
-        clearPromptTimeout();
+        clearPromptTimers();
       },
     };
   });

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,7 +1,7 @@
 import { type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Input, Key, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 
-import { type SandboxConfig } from "./config.ts";
+import { DEFAULT_PERMISSION_PROMPT_TIMEOUT_SECONDS, type SandboxConfig } from "./config.ts";
 import { allowsAllDomains, domainIsAllowed, matchesPattern } from "./policy.ts";
 import { type SessionAllowances } from "./sandbox-runtime.ts";
 
@@ -23,14 +23,16 @@ interface PromptOption {
 const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 export function permissionPromptTimeoutMs(timeoutSeconds: unknown): number | undefined {
+  const resolvedTimeoutSeconds =
+    timeoutSeconds === undefined ? DEFAULT_PERMISSION_PROMPT_TIMEOUT_SECONDS : timeoutSeconds;
   if (
-    typeof timeoutSeconds !== "number" ||
-    !Number.isFinite(timeoutSeconds) ||
-    timeoutSeconds <= 0
+    typeof resolvedTimeoutSeconds !== "number" ||
+    !Number.isFinite(resolvedTimeoutSeconds) ||
+    resolvedTimeoutSeconds <= 0
   ) {
     return undefined;
   }
-  return Math.min(timeoutSeconds * 1000, MAX_TIMER_DELAY_MS);
+  return Math.min(resolvedTimeoutSeconds * 1000, MAX_TIMER_DELAY_MS);
 }
 
 export function permissionPromptRemainingSeconds(deadlineMs: number, nowMs = Date.now()): number {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -69,15 +69,18 @@ test("mergeConfigLayers uses defaults only for arrays not configured by either f
     DEFAULT_CONFIG,
     {
       enabled: false,
+      permissionPromptTimeoutSeconds: 30,
       filesystem: { allowWrite: [] },
     },
     {
       enabled: true,
+      permissionPromptTimeoutSeconds: 0,
       allowBrowserProcess: true,
     },
   );
 
   assert.equal(merged.enabled, true);
+  assert.equal(merged.permissionPromptTimeoutSeconds, 0);
   assert.equal(merged.allowBrowserProcess, true);
   assert.deepEqual(merged.filesystem?.allowWrite, []);
   assert.deepEqual(merged.filesystem?.allowRead, DEFAULT_CONFIG.filesystem?.allowRead);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -10,8 +10,16 @@ import {
   addReadPathToConfig,
   addWritePathToConfig,
   DEFAULT_CONFIG,
+  DEFAULT_PERMISSION_PROMPT_TIMEOUT_SECONDS,
   mergeConfigLayers,
 } from "../src/config.ts";
+
+test("omitted permission prompt timeout defaults to ten minutes", () => {
+  const merged = mergeConfigLayers(DEFAULT_CONFIG, {}, {});
+
+  assert.equal(DEFAULT_PERMISSION_PROMPT_TIMEOUT_SECONDS, 600);
+  assert.equal(merged.permissionPromptTimeoutSeconds, DEFAULT_PERMISSION_PROMPT_TIMEOUT_SECONDS);
+});
 
 test("mergeConfigLayers combines configured arrays and deduplicates entries", () => {
   const merged = mergeConfigLayers(

--- a/test/ui.test.ts
+++ b/test/ui.test.ts
@@ -3,7 +3,11 @@ import test from "node:test";
 import { type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import assert from "node:assert/strict";
 
-import { permissionPromptTimeoutMs, showPermissionPrompt } from "../src/ui.ts";
+import {
+  permissionPromptRemainingSeconds,
+  permissionPromptTimeoutMs,
+  showPermissionPrompt,
+} from "../src/ui.ts";
 
 test("permissionPromptTimeoutMs enables only positive finite timeouts", () => {
   assert.equal(permissionPromptTimeoutMs(undefined), undefined);
@@ -16,11 +20,21 @@ test("permissionPromptTimeoutMs enables only positive finite timeouts", () => {
   assert.equal(permissionPromptTimeoutMs(Number.MAX_VALUE), 2_147_483_647);
 });
 
+test("permissionPromptRemainingSeconds rounds up and stops at zero", () => {
+  const deadlineMs = 10_000;
+  assert.equal(permissionPromptRemainingSeconds(deadlineMs, 7_000), 3);
+  assert.equal(permissionPromptRemainingSeconds(deadlineMs, 7_001), 3);
+  assert.equal(permissionPromptRemainingSeconds(deadlineMs, 8_000), 2);
+  assert.equal(permissionPromptRemainingSeconds(deadlineMs, 9_999), 1);
+  assert.equal(permissionPromptRemainingSeconds(deadlineMs, 10_000), 0);
+  assert.equal(permissionPromptRemainingSeconds(deadlineMs, 11_000), 0);
+});
+
 test(
   "showPermissionPrompt safely aborts when its timeout expires",
   { timeout: 1_000 },
   async () => {
-    type TestComponent = { dispose?(): void };
+    type TestComponent = { render(width: number): string[]; dispose?(): void };
     type PromptFactory<T> = (
       tui: { requestRender(): void },
       theme: { fg(color: string, text: string): string },
@@ -28,6 +42,7 @@ test(
       done: (result: T) => void,
     ) => TestComponent;
 
+    let renderedLines: string[] = [];
     const pi = {
       events: { emit: () => undefined },
     } as unknown as ExtensionAPI;
@@ -47,6 +62,7 @@ test(
               {},
               done,
             );
+            renderedLines = component.render(80);
           }),
       },
     } as unknown as ExtensionContext;
@@ -60,6 +76,7 @@ test(
       0.001,
     );
 
+    assert.ok(renderedLines.includes("⏳ Auto-abort in 1s (permission stays blocked)"));
     assert.deepEqual(result, { action: "abort", value: "example.test" });
   },
 );

--- a/test/ui.test.ts
+++ b/test/ui.test.ts
@@ -1,0 +1,65 @@
+import test from "node:test";
+
+import { type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
+import assert from "node:assert/strict";
+
+import { permissionPromptTimeoutMs, showPermissionPrompt } from "../src/ui.ts";
+
+test("permissionPromptTimeoutMs enables only positive finite timeouts", () => {
+  assert.equal(permissionPromptTimeoutMs(undefined), undefined);
+  assert.equal(permissionPromptTimeoutMs(0), undefined);
+  assert.equal(permissionPromptTimeoutMs(-1), undefined);
+  assert.equal(permissionPromptTimeoutMs(Number.NaN), undefined);
+  assert.equal(permissionPromptTimeoutMs(Number.POSITIVE_INFINITY), undefined);
+  assert.equal(permissionPromptTimeoutMs("30"), undefined);
+  assert.equal(permissionPromptTimeoutMs(30), 30_000);
+  assert.equal(permissionPromptTimeoutMs(Number.MAX_VALUE), 2_147_483_647);
+});
+
+test(
+  "showPermissionPrompt safely aborts when its timeout expires",
+  { timeout: 1_000 },
+  async () => {
+    type TestComponent = { dispose?(): void };
+    type PromptFactory<T> = (
+      tui: { requestRender(): void },
+      theme: { fg(color: string, text: string): string },
+      keybindings: object,
+      done: (result: T) => void,
+    ) => TestComponent;
+
+    const pi = {
+      events: { emit: () => undefined },
+    } as unknown as ExtensionAPI;
+    const ctx = {
+      hasUI: true,
+      ui: {
+        custom: <T>(factory: PromptFactory<T>): Promise<T> =>
+          new Promise<T>((resolve) => {
+            let component: TestComponent | undefined;
+            const done = (result: T): void => {
+              component?.dispose?.();
+              resolve(result);
+            };
+            component = factory(
+              { requestRender: () => undefined },
+              { fg: (_color, text) => text },
+              {},
+              done,
+            );
+          }),
+      },
+    } as unknown as ExtensionContext;
+
+    const result = await showPermissionPrompt(
+      pi,
+      ctx,
+      "Blocked",
+      "example.test",
+      () => null,
+      0.001,
+    );
+
+    assert.deepEqual(result, { action: "abort", value: "example.test" });
+  },
+);

--- a/test/ui.test.ts
+++ b/test/ui.test.ts
@@ -9,8 +9,8 @@ import {
   showPermissionPrompt,
 } from "../src/ui.ts";
 
-test("permissionPromptTimeoutMs enables only positive finite timeouts", () => {
-  assert.equal(permissionPromptTimeoutMs(undefined), undefined);
+test("permissionPromptTimeoutMs defaults omission and enables only positive finite timeouts", () => {
+  assert.equal(permissionPromptTimeoutMs(undefined), 600_000);
   assert.equal(permissionPromptTimeoutMs(0), undefined);
   assert.equal(permissionPromptTimeoutMs(-1), undefined);
   assert.equal(permissionPromptTimeoutMs(Number.NaN), undefined);


### PR DESCRIPTION
## Summary

- add `permissionPromptTimeoutSeconds` with project-over-global scalar precedence
- safely auto-abort network, read, write, and `/sandbox-allow` prompts when the timeout expires
- show a visible `⏳` countdown while a timed permission prompt is open
- preserve indefinite waiting when the setting is omitted, zero, or invalid
- clean up timeout and countdown timers on every prompt completion path

## Testing

- `corepack pnpm exec oxfmt --check index.ts src test`
- `corepack pnpm exec oxlint index.ts src test`
- `corepack pnpm exec tsc --noEmit`
- `node --import tsx --test test/*.test.ts` — 16 tests passed

## Demo


https://github.com/user-attachments/assets/fa377579-699a-48d1-8b70-64dc95d52c39



---

Closes #67