### PR TITLE
fix: respect PI_CODING_AGENT_DIR for global config

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ pi install npm:pi-sandbox
 ```
 
 #### Configure
-Add a config like this either to `~/.pi/agent/sandbox.json` (global) or to `.pi/sandbox.json` (local).
+Add a config like this either to Pi's global agent directory (by default, `~/.pi/agent/sandbox.json`; respects `PI_CODING_AGENT_DIR`) or to `.pi/sandbox.json` (local).
 Scalar settings in the local config take precedence over global settings. The
 path and domain arrays from both files are combined and deduplicated, so a
 project can add permissions without repeating the global configuration. Built-in
@@ -129,7 +129,7 @@ or set it to `0` to wait indefinitely. A timeout never grants permission.
 - Abort (keep blocked)
 - Allow for this session only
 - Allow for this project — written to `.pi/sandbox.json`
-- Allow for all projects — written to `~/.pi/agent/sandbox.json`
+- Allow for all projects — written to Pi's global agent directory (by default, `~/.pi/agent/sandbox.json`; respects `PI_CODING_AGENT_DIR`)
 
 **Session allowances** are held in memory only. They are never written to disk
 and the agent has no way to read or modify them. They are reset when the

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,4 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
 import { type SandboxRuntimeConfig } from "@carderne/sandbox-runtime";
@@ -161,16 +160,15 @@ function readJsonConfig(configPath: string, warn: boolean): SandboxConfigFile {
 
 export function getConfigPaths(cwd: string): { globalPath: string; projectPath: string } {
   return {
-    globalPath: join(homedir(), ".pi", "agent", "sandbox.json"),
+    globalPath: join(getAgentDir(), "sandbox.json"),
     projectPath: join(cwd, ".pi", "sandbox.json"),
   };
 }
 
 export function loadConfig(cwd: string): SandboxConfig {
-  const projectConfigPath = join(cwd, ".pi", "sandbox.json");
-  const globalConfigPath = join(getAgentDir(), "sandbox.json");
-  const globalConfig = readJsonConfig(globalConfigPath, true);
-  const projectConfig = readJsonConfig(projectConfigPath, true);
+  const { globalPath, projectPath } = getConfigPaths(cwd);
+  const globalConfig = readJsonConfig(globalPath, true);
+  const projectConfig = readJsonConfig(projectPath, true);
   return mergeConfigLayers(DEFAULT_CONFIG, globalConfig, projectConfig);
 }
 

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,7 +1,11 @@
 import { type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Input, Key, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 
-import { DEFAULT_PERMISSION_PROMPT_TIMEOUT_SECONDS, type SandboxConfig } from "./config.ts";
+import {
+  DEFAULT_PERMISSION_PROMPT_TIMEOUT_SECONDS,
+  getConfigPaths,
+  type SandboxConfig,
+} from "./config.ts";
 import { allowsAllDomains, domainIsAllowed, matchesPattern } from "./policy.ts";
 import { type SessionAllowances } from "./sandbox-runtime.ts";
 
@@ -39,24 +43,27 @@ export function permissionPromptRemainingSeconds(deadlineMs: number, nowMs = Dat
   return Math.max(0, Math.ceil((deadlineMs - nowMs) / 1000));
 }
 
-const PERMISSION_OPTIONS: PromptOption[] = [
-  { label: "Allow for this session only", key: "s", action: "session" },
-  { label: "Abort (keep blocked)", key: "esc", action: "abort" },
-  {
-    label: "Allow for this project",
-    key: "P",
-    action: "project",
-    confirm: true,
-    hint: "→ .pi/sandbox.json",
-  },
-  {
-    label: "Allow for all projects",
-    key: "A",
-    action: "global",
-    confirm: true,
-    hint: "→ ~/.pi/agent/sandbox.json",
-  },
-];
+export function permissionOptions(cwd: string): PromptOption[] {
+  const { globalPath, projectPath } = getConfigPaths(cwd);
+  return [
+    { label: "Allow for this session only", key: "s", action: "session" },
+    { label: "Abort (keep blocked)", key: "esc", action: "abort" },
+    {
+      label: "Allow for this project",
+      key: "P",
+      action: "project",
+      confirm: true,
+      hint: `→ ${projectPath}`,
+    },
+    {
+      label: "Allow for all projects",
+      key: "A",
+      action: "global",
+      confirm: true,
+      hint: `→ ${globalPath}`,
+    },
+  ];
+}
 
 export async function showPermissionPrompt(
   pi: ExtensionAPI,
@@ -71,6 +78,7 @@ export async function showPermissionPrompt(
   pi.events.emit("request-attention", { message: "Sandbox permission required" });
 
   const timeoutMs = permissionPromptTimeoutMs(timeoutSeconds);
+  const options = permissionOptions(ctx.cwd);
   const result = await ctx.ui.custom<PermissionPromptResult>((tui, theme, _kb, done) => {
     const input = new Input();
     let selectedIndex = 0;
@@ -100,8 +108,7 @@ export async function showPermissionPrompt(
       done(result);
     };
 
-    const selectedOption = (): PromptOption =>
-      PERMISSION_OPTIONS[selectedIndex] ?? PERMISSION_OPTIONS[0]!;
+    const selectedOption = (): PromptOption => options[selectedIndex] ?? options[0]!;
     const isAllowOption = (option: PromptOption): boolean => option.action !== "abort";
     const updateFocus = (): void => {
       input.focused = componentFocused && editing;
@@ -174,8 +181,8 @@ export async function showPermissionPrompt(
           );
         }
         lines.push("");
-        for (let i = 0; i < PERMISSION_OPTIONS.length; i++) {
-          const option = PERMISSION_OPTIONS[i]!;
+        for (let i = 0; i < options.length; i++) {
+          const option = options[i]!;
           const isSelected = i === selectedIndex;
           const prefix = isSelected ? " → " : "   ";
           const keyHint = theme.fg("accent", `[${option.key}]`);
@@ -225,10 +232,7 @@ export async function showPermissionPrompt(
           }
           if (matchesKey(data, Key.up) || matchesKey(data, Key.down)) {
             const delta = matchesKey(data, Key.up) ? -1 : 1;
-            selectedIndex = Math.max(
-              0,
-              Math.min(PERMISSION_OPTIONS.length - 1, selectedIndex + delta),
-            );
+            selectedIndex = Math.max(0, Math.min(options.length - 1, selectedIndex + delta));
             pendingAction = null;
             stopEditing();
             tui.requestRender();
@@ -254,16 +258,13 @@ export async function showPermissionPrompt(
         }
         if (matchesKey(data, Key.up) || matchesKey(data, Key.down)) {
           const delta = matchesKey(data, Key.up) ? -1 : 1;
-          selectedIndex = Math.max(
-            0,
-            Math.min(PERMISSION_OPTIONS.length - 1, selectedIndex + delta),
-          );
+          selectedIndex = Math.max(0, Math.min(options.length - 1, selectedIndex + delta));
           pendingAction = null;
           tui.requestRender();
           return;
         }
-        for (let i = 0; i < PERMISSION_OPTIONS.length; i++) {
-          const option = PERMISSION_OPTIONS[i]!;
+        for (let i = 0; i < options.length; i++) {
+          const option = options[i]!;
           if (data === option.key) {
             resolve(option.action);
             return;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -11,6 +11,7 @@ import {
   addWritePathToConfig,
   DEFAULT_CONFIG,
   DEFAULT_PERMISSION_PROMPT_TIMEOUT_SECONDS,
+  getConfigPaths,
   mergeConfigLayers,
 } from "../src/config.ts";
 
@@ -93,6 +94,20 @@ test("mergeConfigLayers uses defaults only for arrays not configured by either f
   assert.deepEqual(merged.filesystem?.allowWrite, []);
   assert.deepEqual(merged.filesystem?.allowRead, DEFAULT_CONFIG.filesystem?.allowRead);
   assert.deepEqual(merged.network?.allowedDomains, DEFAULT_CONFIG.network?.allowedDomains);
+});
+
+test("getConfigPaths uses Pi's configured agent directory", () => {
+  const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = "/tmp/custom-pi-agent";
+  try {
+    assert.deepEqual(getConfigPaths("/workspace"), {
+      globalPath: "/tmp/custom-pi-agent/sandbox.json",
+      projectPath: "/workspace/.pi/sandbox.json",
+    });
+  } finally {
+    if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+  }
 });
 
 test("permission writers only persist the property being changed", () => {

--- a/test/ui.test.ts
+++ b/test/ui.test.ts
@@ -4,6 +4,7 @@ import { type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-cod
 import assert from "node:assert/strict";
 
 import {
+  permissionOptions,
   permissionPromptRemainingSeconds,
   permissionPromptTimeoutMs,
   showPermissionPrompt,
@@ -18,6 +19,17 @@ test("permissionPromptTimeoutMs defaults omission and enables only positive fini
   assert.equal(permissionPromptTimeoutMs("30"), undefined);
   assert.equal(permissionPromptTimeoutMs(30), 30_000);
   assert.equal(permissionPromptTimeoutMs(Number.MAX_VALUE), 2_147_483_647);
+});
+
+test("permissionOptions displays Pi's configured global path", () => {
+  const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = "/tmp/custom-pi-agent";
+  try {
+    assert.equal(permissionOptions("/workspace")[3]?.hint, "→ /tmp/custom-pi-agent/sandbox.json");
+  } finally {
+    if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+  }
 });
 
 test("permissionPromptRemainingSeconds rounds up and stops at zero", () => {
@@ -47,6 +59,7 @@ test(
       events: { emit: () => undefined },
     } as unknown as ExtensionAPI;
     const ctx = {
+      cwd: "/workspace",
       hasUI: true,
       ui: {
         custom: <T>(factory: PromptFactory<T>): Promise<T> =>


### PR DESCRIPTION
   ## Summary

   Fix global sandbox permission persistence when Pi is launched with
   `PI_CODING_AGENT_DIR`.

   `loadConfig()` already reads the global config from:

```text
   ${getAgentDir()}/sandbox.json
 ```

 but getConfigPaths() previously wrote global grants to the hardcoded default:

 ```text
   ~/.pi/agent/sandbox.json
 ```

 As a result, selecting “Allow for all projects” could write a permission
 grant to a file that loadConfig() would not read on the next session.

 This change:

 - uses getAgentDir() in getConfigPaths() so global config reads and writes
   use the same path;
 - makes permission prompt hints show the actual project/global config paths;
 - adds regression coverage for PI_CODING_AGENT_DIR.

 Example

 With:

 ```bash
   PI_CODING_AGENT_DIR=/custom/pi-agent
 ```

 global permissions are now both read from and written to:

 ```text
   /custom/pi-agent/sandbox.json
 ```