### PR TITLE
Fix bash write prompts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,4 +4,3 @@
  */
 
 export { default } from "./src/extension.ts";
-export { shouldPromptForWrite } from "./src/policy.ts";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,10 +16,10 @@ import {
 } from "./config.ts";
 import {
   canonicalizePath,
-  decideWritePolicy,
   domainIsAllowed,
   extractDomainsFromCommand,
   matchesPattern,
+  resolveWritePermission,
 } from "./policy.ts";
 import {
   createSandboxedBashOps,
@@ -209,34 +209,32 @@ export default function (pi: ExtensionAPI) {
         if (blockedPath) {
           const path = canonicalizePath(blockedPath);
           const config = loadConfig(ctx.cwd);
-          const writePolicy = decideWritePolicy(
+          const writePermission = await resolveWritePermission({
             path,
-            effectiveWritePaths(ctx.cwd),
-            config.filesystem?.denyWrite ?? [],
-          );
-          if (writePolicy === "deny") {
+            allowWrite: effectiveWritePaths(ctx.cwd),
+            denyWrite: config.filesystem?.denyWrite ?? [],
+            prompt: (path) =>
+              promptWriteBlock(pi, ctx, path, config.permissionPromptTimeoutSeconds),
+            saveWritePermission: (choice, value) => applyChoice(choice, "write", value, ctx.cwd),
+          });
+          if (writePermission.action === "deny") {
             return result;
           }
-          if (writePolicy === "prompt") {
-            const choice = await promptWriteBlock(
-              pi,
-              ctx,
-              path,
-              config.permissionPromptTimeoutSeconds,
-            );
-            if (choice.action !== "abort") {
-              await applyChoice(choice.action, "write", choice.value, ctx.cwd);
-              onUpdate?.({
-                content: [
-                  {
-                    type: "text",
-                    text: `\n--- Write access granted for "${choice.value}", retrying ---\n`,
-                  },
-                ],
-                details: {},
-              });
-              return runBash();
-            }
+          if (writePermission.action === "allow") {
+            await refreshSandbox(ctx.cwd);
+            return runBash();
+          }
+          if (writePermission.action === "granted") {
+            onUpdate?.({
+              content: [
+                {
+                  type: "text",
+                  text: `\n--- Write access granted for "${writePermission.value}", retrying ---\n`,
+                },
+              ],
+              details: {},
+            });
+            return runBash();
           }
         }
       }
@@ -317,12 +315,14 @@ export default function (pi: ExtensionAPI) {
 
     if (isToolCallEventType("write", event) || isToolCallEventType("edit", event)) {
       const path = canonicalizePath((event.input as { path: string }).path);
-      const writePolicy = decideWritePolicy(
+      const writePermission = await resolveWritePermission({
         path,
-        effectiveWritePaths(ctx.cwd),
-        config.filesystem?.denyWrite ?? [],
-      );
-      if (writePolicy === "deny") {
+        allowWrite: effectiveWritePaths(ctx.cwd),
+        denyWrite: config.filesystem?.denyWrite ?? [],
+        prompt: (path) => promptWriteBlock(pi, ctx, path, config.permissionPromptTimeoutSeconds),
+        saveWritePermission: (choice, value) => applyChoice(choice, "write", value, ctx.cwd),
+      });
+      if (writePermission.action === "deny") {
         return {
           block: true,
           reason:
@@ -330,15 +330,13 @@ export default function (pi: ExtensionAPI) {
             `To change this, edit denyWrite in:\n  ${projectPath}\n  ${globalPath}`,
         };
       }
-      if (writePolicy === "prompt") {
-        const choice = await promptWriteBlock(pi, ctx, path, config.permissionPromptTimeoutSeconds);
-        if (choice.action === "abort") {
-          return {
-            block: true,
-            reason: `Sandbox: write access denied for "${path}" (not in allowWrite)`,
-          };
-        }
-        await applyChoice(choice.action, "write", choice.value, ctx.cwd);
+      if (writePermission.action === "abort") {
+        return {
+          block: true,
+          reason: `Sandbox: write access denied for "${path}" (not in allowWrite)`,
+        };
+      }
+      if (writePermission.action === "granted") {
         return;
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -207,34 +207,32 @@ export default function (pi: ExtensionAPI) {
         const blockedPath = extractBlockedWritePath(output);
 
         if (blockedPath) {
-          const choice = await promptWriteBlock(
-            pi,
-            ctx,
-            blockedPath,
-            loadConfig(ctx.cwd).permissionPromptTimeoutSeconds,
-          );
-          if (choice.action !== "abort") {
-            await applyChoice(choice.action, "write", choice.value, ctx.cwd);
-            const config = loadConfig(ctx.cwd);
-            const { projectPath, globalPath } = getConfigPaths(ctx.cwd);
-            if (matchesPattern(blockedPath, config.filesystem?.denyWrite ?? [])) {
-              ctx.ui.notify(
-                `⚠️ "${choice.value}" was added to allowWrite, but "${blockedPath}" is also in denyWrite and will remain blocked.\n` +
-                  `Check denyWrite in:\n  ${projectPath}\n  ${globalPath}`,
-                "warning",
-              );
-              return result;
+          const path = canonicalizePath(blockedPath);
+          const config = loadConfig(ctx.cwd);
+          const denyWrite = config.filesystem?.denyWrite ?? [];
+          if (matchesPattern(path, denyWrite)) {
+            return result;
+          }
+          if (shouldPromptForWrite(path, effectiveWritePaths(ctx.cwd), matchesPattern)) {
+            const choice = await promptWriteBlock(
+              pi,
+              ctx,
+              path,
+              config.permissionPromptTimeoutSeconds,
+            );
+            if (choice.action !== "abort") {
+              await applyChoice(choice.action, "write", choice.value, ctx.cwd);
+              onUpdate?.({
+                content: [
+                  {
+                    type: "text",
+                    text: `\n--- Write access granted for "${choice.value}", retrying ---\n`,
+                  },
+                ],
+                details: {},
+              });
+              return runBash();
             }
-            onUpdate?.({
-              content: [
-                {
-                  type: "text",
-                  text: `\n--- Write access granted for "${choice.value}", retrying ---\n`,
-                },
-              ],
-              details: {},
-            });
-            return runBash();
           }
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,10 +16,10 @@ import {
 } from "./config.ts";
 import {
   canonicalizePath,
+  decideWritePolicy,
   domainIsAllowed,
   extractDomainsFromCommand,
   matchesPattern,
-  shouldPromptForWrite,
 } from "./policy.ts";
 import {
   createSandboxedBashOps,
@@ -209,11 +209,15 @@ export default function (pi: ExtensionAPI) {
         if (blockedPath) {
           const path = canonicalizePath(blockedPath);
           const config = loadConfig(ctx.cwd);
-          const denyWrite = config.filesystem?.denyWrite ?? [];
-          if (matchesPattern(path, denyWrite)) {
+          const writePolicy = decideWritePolicy(
+            path,
+            effectiveWritePaths(ctx.cwd),
+            config.filesystem?.denyWrite ?? [],
+          );
+          if (writePolicy === "deny") {
             return result;
           }
-          if (shouldPromptForWrite(path, effectiveWritePaths(ctx.cwd), matchesPattern)) {
+          if (writePolicy === "prompt") {
             const choice = await promptWriteBlock(
               pi,
               ctx,
@@ -313,8 +317,12 @@ export default function (pi: ExtensionAPI) {
 
     if (isToolCallEventType("write", event) || isToolCallEventType("edit", event)) {
       const path = canonicalizePath((event.input as { path: string }).path);
-      const denyWrite = config.filesystem?.denyWrite ?? [];
-      if (matchesPattern(path, denyWrite)) {
+      const writePolicy = decideWritePolicy(
+        path,
+        effectiveWritePaths(ctx.cwd),
+        config.filesystem?.denyWrite ?? [],
+      );
+      if (writePolicy === "deny") {
         return {
           block: true,
           reason:
@@ -322,7 +330,7 @@ export default function (pi: ExtensionAPI) {
             `To change this, edit denyWrite in:\n  ${projectPath}\n  ${globalPath}`,
         };
       }
-      if (shouldPromptForWrite(path, effectiveWritePaths(ctx.cwd), matchesPattern)) {
+      if (writePolicy === "prompt") {
         const choice = await promptWriteBlock(pi, ctx, path, config.permissionPromptTimeoutSeconds);
         if (choice.action === "abort") {
           return {

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -10,6 +10,12 @@ export function shouldPromptForWrite(
   return allowWrite.length === 0 || !matches(path, allowWrite);
 }
 
+export function decideWritePolicy(path: string, allowWrite: string[], denyWrite: string[]) {
+  if (matchesPattern(path, denyWrite)) return "deny";
+  if (allowWrite.length === 0 || !matchesPattern(path, allowWrite)) return "prompt";
+  return "allow";
+}
+
 export function extractDomainsFromCommand(command: string): string[] {
   const urlRegex = /https?:\/\/([a-zA-Z0-9][a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/g;
   const domains = new Set<string>();

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -8,6 +8,32 @@ export function decideWritePolicy(path: string, allowWrite: string[], denyWrite:
   return "allow";
 }
 
+export async function resolveWritePermission({
+  path,
+  allowWrite,
+  denyWrite,
+  prompt,
+  saveWritePermission,
+}: {
+  path: string;
+  allowWrite: string[];
+  denyWrite: string[];
+  prompt: (path: string) => Promise<{
+    action: "abort" | "session" | "project" | "global";
+    value: string;
+  }>;
+  saveWritePermission: (choice: "session" | "project" | "global", value: string) => Promise<void>;
+}) {
+  const policy = decideWritePolicy(path, allowWrite, denyWrite);
+  if (policy !== "prompt") return { action: policy };
+
+  const choice = await prompt(path);
+  if (choice.action === "abort") return { action: "abort", value: choice.value };
+
+  await saveWritePermission(choice.action, choice.value);
+  return { action: "granted", value: choice.value };
+}
+
 export function extractDomainsFromCommand(command: string): string[] {
   const urlRegex = /https?:\/\/([a-zA-Z0-9][a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/g;
   const domains = new Set<string>();

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -2,14 +2,6 @@ import { existsSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, resolve } from "node:path";
 
-export function shouldPromptForWrite(
-  path: string,
-  allowWrite: string[],
-  matches: (path: string, patterns: string[]) => boolean,
-): boolean {
-  return allowWrite.length === 0 || !matches(path, allowWrite);
-}
-
 export function decideWritePolicy(path: string, allowWrite: string[], denyWrite: string[]) {
   if (matchesPattern(path, denyWrite)) return "deny";
   if (allowWrite.length === 0 || !matchesPattern(path, allowWrite)) return "prompt";

--- a/src/sandbox-runtime.ts
+++ b/src/sandbox-runtime.ts
@@ -9,7 +9,7 @@ import {
 import { type BashOperations, getShellConfig } from "@earendil-works/pi-coding-agent";
 
 import { type SandboxConfig } from "./config.ts";
-import { domainIsAllowed } from "./policy.ts";
+import { canonicalizePath, domainIsAllowed } from "./policy.ts";
 
 export interface SessionAllowances {
   domains: string[];
@@ -26,6 +26,12 @@ export interface EffectiveAllowances {
 function unique(values: string[]): string[] {
   return [...new Set(values)];
 }
+
+const canonicalizeFilesystemPattern = (path: string) =>
+  path.includes("*") ? path : canonicalizePath(path);
+
+const canonicalizeFilesystemPatterns = (paths: string[]) =>
+  unique(paths.map(canonicalizeFilesystemPattern));
 
 export function resolveAllowances(
   config: SandboxConfig,
@@ -64,11 +70,11 @@ export function buildRuntimeConfig(
       deniedDomains: config.network?.deniedDomains ?? [],
     },
     filesystem: {
-      ...config.filesystem,
-      denyRead: config.filesystem?.denyRead ?? [],
-      allowRead: effective.readPaths,
-      allowWrite: effective.writePaths,
-      denyWrite: config.filesystem?.denyWrite ?? [],
+      disabled: config.filesystem?.disabled,
+      denyRead: canonicalizeFilesystemPatterns(config.filesystem?.denyRead ?? []),
+      allowRead: canonicalizeFilesystemPatterns(effective.readPaths),
+      allowWrite: canonicalizeFilesystemPatterns(effective.writePaths),
+      denyWrite: canonicalizeFilesystemPatterns(config.filesystem?.denyWrite ?? []),
     },
     ignoreViolations: config.ignoreViolations,
     enableWeakerNestedSandbox: config.enableWeakerNestedSandbox,

--- a/test/policy.test.ts
+++ b/test/policy.test.ts
@@ -12,7 +12,6 @@ import {
   domainIsAllowed,
   extractDomainsFromCommand,
   matchesPattern,
-  shouldPromptForWrite,
 } from "../src/policy.ts";
 
 test("extracts and deduplicates literal HTTP domains", () => {
@@ -27,11 +26,6 @@ test("matches exact, wildcard, and all-domain policies", () => {
   assert.equal(domainIsAllowed("api.github.com", ["*.github.com"]), true);
   assert.equal(domainIsAllowed("notgithub.com", ["*.github.com"]), false);
   assert.equal(allowsAllDomains(["*"]), true);
-});
-
-test("empty allowWrite prompts securely", () => {
-  assert.equal(shouldPromptForWrite("/tmp/file", [], matchesPattern), true);
-  assert.equal(shouldPromptForWrite("/tmp/file", ["/tmp"], matchesPattern), false);
 });
 
 test("decides write policy from deny and allow lists", () => {

--- a/test/policy.test.ts
+++ b/test/policy.test.ts
@@ -8,6 +8,7 @@ import assert from "node:assert/strict";
 import {
   allowsAllDomains,
   canonicalizePath,
+  decideWritePolicy,
   domainIsAllowed,
   extractDomainsFromCommand,
   matchesPattern,
@@ -31,6 +32,13 @@ test("matches exact, wildcard, and all-domain policies", () => {
 test("empty allowWrite prompts securely", () => {
   assert.equal(shouldPromptForWrite("/tmp/file", [], matchesPattern), true);
   assert.equal(shouldPromptForWrite("/tmp/file", ["/tmp"], matchesPattern), false);
+});
+
+test("decides write policy from deny and allow lists", () => {
+  assert.equal(decideWritePolicy("/tmp/file", ["/tmp"], ["/tmp/file"]), "deny");
+  assert.equal(decideWritePolicy("/tmp/file", ["/tmp"], []), "allow");
+  assert.equal(decideWritePolicy("/tmp/file", ["/var"], []), "prompt");
+  assert.equal(decideWritePolicy("/tmp/file", [], []), "prompt");
 });
 
 test("path patterns support directory prefixes and globs", () => {

--- a/test/policy.test.ts
+++ b/test/policy.test.ts
@@ -12,6 +12,7 @@ import {
   domainIsAllowed,
   extractDomainsFromCommand,
   matchesPattern,
+  resolveWritePermission,
 } from "../src/policy.ts";
 
 test("extracts and deduplicates literal HTTP domains", () => {
@@ -33,6 +34,70 @@ test("decides write policy from deny and allow lists", () => {
   assert.equal(decideWritePolicy("/tmp/file", ["/tmp"], []), "allow");
   assert.equal(decideWritePolicy("/tmp/file", ["/var"], []), "prompt");
   assert.equal(decideWritePolicy("/tmp/file", [], []), "prompt");
+});
+
+test("resolves write permission without prompting for denied or allowed paths", async () => {
+  const calls: string[] = [];
+  const prompt = async () => {
+    calls.push("prompt");
+    return { action: "session" as const, value: "/tmp" };
+  };
+  const apply = async () => {
+    calls.push("apply");
+  };
+
+  assert.deepEqual(
+    await resolveWritePermission({
+      path: "/tmp/file",
+      allowWrite: ["/tmp"],
+      denyWrite: ["/tmp/file"],
+      prompt,
+      saveWritePermission: apply,
+    }),
+    { action: "deny" },
+  );
+  assert.deepEqual(
+    await resolveWritePermission({
+      path: "/tmp/file",
+      allowWrite: ["/tmp"],
+      denyWrite: [],
+      prompt,
+      saveWritePermission: apply,
+    }),
+    { action: "allow" },
+  );
+  assert.deepEqual(calls, []);
+});
+
+test("resolves write permission prompt choices", async () => {
+  const applied: string[] = [];
+  assert.deepEqual(
+    await resolveWritePermission({
+      path: "/tmp/file",
+      allowWrite: [],
+      denyWrite: [],
+      prompt: async () => ({ action: "abort", value: "/tmp/file" }),
+      saveWritePermission: async (choice, value) => {
+        applied.push(`${choice}:${value}`);
+      },
+    }),
+    { action: "abort", value: "/tmp/file" },
+  );
+  assert.deepEqual(applied.length, 0);
+
+  assert.deepEqual(
+    await resolveWritePermission({
+      path: "/tmp/file",
+      allowWrite: [],
+      denyWrite: [],
+      prompt: async () => ({ action: "session", value: "/tmp" }),
+      saveWritePermission: async (choice, value) => {
+        applied.push(`${choice}:${value}`);
+      },
+    }),
+    { action: "granted", value: "/tmp" },
+  );
+  assert.deepEqual(applied, ["session:/tmp"]);
 });
 
 test("path patterns support directory prefixes and globs", () => {

--- a/test/sandbox-runtime.test.ts
+++ b/test/sandbox-runtime.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { DEFAULT_CONFIG } from "../src/config.ts";
+import { canonicalizePath } from "../src/policy.ts";
 import {
   buildRuntimeConfig,
   extractBlockedWritePath,
@@ -21,6 +22,24 @@ test("buildRuntimeConfig adds session allowances without mutating config", () =>
   assert.equal(runtime.filesystem?.allowRead?.includes("/write"), true);
   assert.equal(runtime.filesystem?.allowWrite?.includes("/write"), true);
   assert.equal(DEFAULT_CONFIG.network?.allowedDomains?.includes("example.com"), false);
+});
+
+test("buildRuntimeConfig canonicalizes non-glob filesystem paths", () => {
+  const runtime = buildRuntimeConfig({
+    ...DEFAULT_CONFIG,
+    filesystem: {
+      ...DEFAULT_CONFIG.filesystem!,
+      denyRead: ["/tmp"],
+      allowRead: [],
+      allowWrite: ["/tmp"],
+      denyWrite: ["*.key"],
+    },
+  });
+
+  assert.deepEqual(runtime.filesystem?.denyRead, [canonicalizePath("/tmp")]);
+  assert.equal(runtime.filesystem?.allowRead?.includes(canonicalizePath("/tmp")), true);
+  assert.deepEqual(runtime.filesystem?.allowWrite, [canonicalizePath("/tmp")]);
+  assert.deepEqual(runtime.filesystem?.denyWrite, ["*.key"]);
 });
 
 test("resolveAllowances makes configured and session write paths readable", () => {


### PR DESCRIPTION
Fixes #72 

This also resolves symlinks in the permission lists before passing them to the sandbox runtime since `/tmp` on macOS is a symlink.

Seemed like exporting `shouldPromptForWrite` from `index.ts` was a mistake so there's a commit deleting that which can be dropped if necessary.