### PR TITLE
Pass allowPty through to the Pi sandbox extension

### DIFF
--- a/src/sandbox-runtime.ts
+++ b/src/sandbox-runtime.ts
@@ -79,6 +79,7 @@ export function buildRuntimeConfig(
     ignoreViolations: config.ignoreViolations,
     enableWeakerNestedSandbox: config.enableWeakerNestedSandbox,
     allowBrowserProcess: config.allowBrowserProcess,
+    allowPty: config.allowPty,
     enableWeakerNetworkIsolation: true,
   };
 }


### PR DESCRIPTION
Passing Anthropic's sandbox-runtime option to the extension. This allows Pi to spawn tmux sessions on macOS.

I tested on my mac and it worked.