### PR TITLE
fix: hang after agent runs a subprocess

### DIFF
--- a/src/sandbox-runtime.ts
+++ b/src/sandbox-runtime.ts
@@ -170,6 +170,16 @@ export function createSandboxedBashOps(shellPath?: string, sshProxy = true): Bas
           reject(error);
         });
 
+        // A daemonized grandchild (e.g. Chrome's GoogleUpdater) can inherit the
+        // piped stdio fds, which would delay the "close" event (and the exec
+        // promise) until those fds close. Tear down our pipes as soon as the
+        // direct child process exits so "close" fires promptly and the command
+        // returns even while background agents keep running.
+        child.on("exit", () => {
+          child.stdout?.destroy();
+          child.stderr?.destroy();
+        });
+
         signal?.addEventListener("abort", killProcessGroup, { once: true });
         child.on("close", (code) => {
           if (timeoutHandle) clearTimeout(timeoutHandle);

--- a/src/sandbox-runtime.ts
+++ b/src/sandbox-runtime.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
 
 import {
@@ -115,6 +115,98 @@ export function extractBlockedWritePath(output: string): string | null {
   return match ? match[1] : null;
 }
 
+const EXIT_STDIO_GRACE_MS = 100;
+
+/**
+ * Wait for a child process to exit without hanging on inherited stdio handles.
+ *
+ * After exit, keep reading while output is active. If a detached descendant
+ * holds the pipes open but leaves them idle, release them after a short grace.
+ */
+function waitForChildProcess(child: ChildProcess): Promise<number | null> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let exited = false;
+    let exitCode: number | null = null;
+    let postExitTimer: NodeJS.Timeout | undefined;
+    let stdoutEnded = child.stdout === null;
+    let stderrEnded = child.stderr === null;
+
+    const cleanup = () => {
+      if (postExitTimer) {
+        clearTimeout(postExitTimer);
+        postExitTimer = undefined;
+      }
+      child.removeListener("error", onError);
+      child.removeListener("exit", onExit);
+      child.removeListener("close", onClose);
+      child.stdout?.removeListener("end", onStdoutEnd);
+      child.stderr?.removeListener("end", onStderrEnd);
+      child.stdout?.removeListener("data", onData);
+      child.stderr?.removeListener("data", onData);
+    };
+
+    const finalize = (code: number | null) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      child.stdout?.destroy();
+      child.stderr?.destroy();
+      resolve(code);
+    };
+
+    const maybeFinalizeAfterExit = () => {
+      if (!exited || settled) return;
+      if (stdoutEnded && stderrEnded) finalize(exitCode);
+    };
+
+    const armIdleTimer = () => {
+      if (postExitTimer) clearTimeout(postExitTimer);
+      postExitTimer = setTimeout(() => finalize(exitCode), EXIT_STDIO_GRACE_MS);
+    };
+
+    const onData = () => {
+      if (exited && !settled) armIdleTimer();
+    };
+
+    const onStdoutEnd = () => {
+      stdoutEnded = true;
+      maybeFinalizeAfterExit();
+    };
+
+    const onStderrEnd = () => {
+      stderrEnded = true;
+      maybeFinalizeAfterExit();
+    };
+
+    const onError = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+
+    const onExit = (code: number | null) => {
+      exited = true;
+      exitCode = code;
+      maybeFinalizeAfterExit();
+      if (!settled) armIdleTimer();
+    };
+
+    const onClose = (code: number | null) => {
+      finalize(code);
+    };
+
+    child.stdout?.once("end", onStdoutEnd);
+    child.stderr?.once("end", onStderrEnd);
+    child.stdout?.on("data", onData);
+    child.stderr?.on("data", onData);
+    child.once("error", onError);
+    child.once("exit", onExit);
+    child.once("close", onClose);
+  });
+}
+
 export function createSandboxedBashOps(shellPath?: string, sshProxy = true): BashOperations {
   return {
     async exec(command, cwd, { onData, signal, timeout, env }) {
@@ -136,61 +228,46 @@ export function createSandboxedBashOps(shellPath?: string, sshProxy = true): Bas
         shell,
       );
 
-      return new Promise((resolve, reject) => {
-        const child = spawn(shell, [...args, wrappedCommand], {
-          cwd,
-          env,
-          detached: true,
-          stdio: ["ignore", "pipe", "pipe"],
-        });
-
-        let timedOut = false;
-        let timeoutHandle: NodeJS.Timeout | undefined;
-
-        const killProcessGroup = () => {
-          if (!child.pid) return;
-          try {
-            process.kill(-child.pid, "SIGKILL");
-          } catch {
-            child.kill("SIGKILL");
-          }
-        };
-
-        if (timeout !== undefined && timeout > 0) {
-          timeoutHandle = setTimeout(() => {
-            timedOut = true;
-            killProcessGroup();
-          }, timeout * 1000);
-        }
-
-        child.stdout?.on("data", onData);
-        child.stderr?.on("data", onData);
-        child.on("error", (error) => {
-          if (timeoutHandle) clearTimeout(timeoutHandle);
-          reject(error);
-        });
-
-        // A daemonized grandchild (e.g. Chrome's GoogleUpdater) can inherit the
-        // piped stdio fds, which would delay the "close" event (and the exec
-        // promise) until those fds close. Tear down our pipes as soon as the
-        // direct child process exits so "close" fires promptly and the command
-        // returns even while background agents keep running.
-        child.on("exit", () => {
-          child.stdout?.destroy();
-          child.stderr?.destroy();
-        });
-
-        signal?.addEventListener("abort", killProcessGroup, { once: true });
-        child.on("close", (code) => {
-          if (timeoutHandle) clearTimeout(timeoutHandle);
-          signal?.removeEventListener("abort", killProcessGroup);
-          SandboxManager.cleanupAfterCommand();
-
-          if (signal?.aborted) reject(new Error("aborted"));
-          else if (timedOut) reject(new Error(`timeout:${timeout}`));
-          else resolve({ exitCode: code });
-        });
+      const child = spawn(shell, [...args, wrappedCommand], {
+        cwd,
+        env,
+        detached: true,
+        stdio: ["ignore", "pipe", "pipe"],
       });
+
+      let timedOut = false;
+      let timeoutHandle: NodeJS.Timeout | undefined;
+
+      const killProcessGroup = () => {
+        if (!child.pid) return;
+        try {
+          process.kill(-child.pid, "SIGKILL");
+        } catch {
+          child.kill("SIGKILL");
+        }
+      };
+
+      if (timeout !== undefined && timeout > 0) {
+        timeoutHandle = setTimeout(() => {
+          timedOut = true;
+          killProcessGroup();
+        }, timeout * 1000);
+      }
+
+      child.stdout?.on("data", onData);
+      child.stderr?.on("data", onData);
+      signal?.addEventListener("abort", killProcessGroup, { once: true });
+
+      try {
+        const exitCode = await waitForChildProcess(child);
+        if (signal?.aborted) throw new Error("aborted");
+        if (timedOut) throw new Error(`timeout:${timeout}`);
+        return { exitCode };
+      } finally {
+        if (timeoutHandle) clearTimeout(timeoutHandle);
+        signal?.removeEventListener("abort", killProcessGroup);
+        SandboxManager.cleanupAfterCommand();
+      }
     },
   };
 }

--- a/test/sandbox-runtime.test.ts
+++ b/test/sandbox-runtime.test.ts
@@ -1,11 +1,17 @@
-import test from "node:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { mock } from "node:test";
 
 import assert from "node:assert/strict";
+
+import { SandboxManager } from "@carderne/sandbox-runtime";
 
 import { DEFAULT_CONFIG } from "../src/config.ts";
 import { canonicalizePath } from "../src/policy.ts";
 import {
   buildRuntimeConfig,
+  createSandboxedBashOps,
   extractBlockedWritePath,
   resolveAllowances,
   supportsNodeEnvProxy,
@@ -74,4 +80,25 @@ test("supportsNodeEnvProxy observes Node release boundaries", () => {
   assert.equal(supportsNodeEnvProxy("22.21.0"), true);
   assert.equal(supportsNodeEnvProxy("23.9.0"), false);
   assert.equal(supportsNodeEnvProxy("24.0.0"), true);
+});
+
+test("exec resolves when the command exits even if a daemonized grandchild holds the stdio pipes", async (t) => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-sandbox-exec-"));
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+
+  // Exercise exec without an OS sandbox session: identity wrap, no SSH proxy.
+  mock.method(SandboxManager, "wrapWithSandbox", async (command: string) => command);
+  t.after(() => mock.restoreAll());
+
+  const exec = createSandboxedBashOps(undefined, false).exec;
+
+  // The backgrounded subshell inherits stdout/stderr, so it keeps exec's
+  // pipes open ~5s after the shell itself exits. The promise must resolve
+  // as soon as the direct child exits - not when the daemonized child dies.
+  const started = Date.now();
+  const { exitCode } = await exec("(sleep 5) &", cwd, { onData: () => {} });
+  const elapsed = Date.now() - started;
+
+  assert.equal(exitCode, 0);
+  assert.ok(elapsed < 2000, `exec returned after ${elapsed}ms; expected early teardown`);
 });

--- a/test/sandbox-runtime.test.ts
+++ b/test/sandbox-runtime.test.ts
@@ -1,11 +1,10 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import test, { mock } from "node:test";
-
-import assert from "node:assert/strict";
+import test, { mock, type TestContext } from "node:test";
 
 import { SandboxManager } from "@carderne/sandbox-runtime";
+import assert from "node:assert/strict";
 
 import { DEFAULT_CONFIG } from "../src/config.ts";
 import { canonicalizePath } from "../src/policy.ts";
@@ -16,6 +15,60 @@ import {
   resolveAllowances,
   supportsNodeEnvProxy,
 } from "../src/sandbox-runtime.ts";
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function createExecTestContext(t: TestContext) {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-sandbox-exec-"));
+  const backgroundPidPaths: string[] = [];
+
+  // Exercise exec without an OS sandbox session: identity wrap, no SSH proxy.
+  mock.method(SandboxManager, "wrapWithSandbox", async (command: string) => command);
+  t.after(() => {
+    try {
+      for (const pidPath of backgroundPidPaths) terminateRecordedProcess(pidPath);
+    } finally {
+      mock.restoreAll();
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  return {
+    cwd,
+    exec: createSandboxedBashOps(undefined, false).exec,
+    trackBackgroundProcess: (pidPath: string) => backgroundPidPaths.push(pidPath),
+  };
+}
+
+function terminateRecordedProcess(pidPath: string): void {
+  try {
+    const pid = Number.parseInt(readFileSync(pidPath, "utf8"), 10);
+    process.kill(pid, "SIGKILL");
+  } catch (error) {
+    if (
+      !(error instanceof Error) ||
+      !("code" in error) ||
+      (error.code !== "ENOENT" && error.code !== "ESRCH")
+    ) {
+      throw error;
+    }
+  }
+}
+
+function backgroundNodeCommand(cwd: string, source: string): { command: string; pidPath: string } {
+  const pidPath = join(cwd, "background.pid");
+  const childSource = [
+    `require("node:fs").writeFileSync(${JSON.stringify(pidPath)}, String(process.pid));`,
+    source,
+  ].join("\n");
+  const command = [
+    `${shellQuote(process.execPath)} -e ${shellQuote(childSource)} &`,
+    `while [ ! -s ${shellQuote(pidPath)} ]; do sleep 0.01; done`,
+  ].join(" ");
+  return { command, pidPath };
+}
 
 test("buildRuntimeConfig adds session allowances without mutating config", () => {
   const runtime = buildRuntimeConfig(DEFAULT_CONFIG, {
@@ -83,22 +136,72 @@ test("supportsNodeEnvProxy observes Node release boundaries", () => {
 });
 
 test("exec resolves when the command exits even if a daemonized grandchild holds the stdio pipes", async (t) => {
-  const cwd = mkdtempSync(join(tmpdir(), "pi-sandbox-exec-"));
-  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+  const { cwd, exec, trackBackgroundProcess } = createExecTestContext(t);
+  const { command, pidPath } = backgroundNodeCommand(cwd, "setInterval(() => {}, 1000);");
+  trackBackgroundProcess(pidPath);
 
-  // Exercise exec without an OS sandbox session: identity wrap, no SSH proxy.
-  mock.method(SandboxManager, "wrapWithSandbox", async (command: string) => command);
-  t.after(() => mock.restoreAll());
-
-  const exec = createSandboxedBashOps(undefined, false).exec;
-
-  // The backgrounded subshell inherits stdout/stderr, so it keeps exec's
-  // pipes open ~5s after the shell itself exits. The promise must resolve
-  // as soon as the direct child exits - not when the daemonized child dies.
+  // The background process inherits stdout/stderr indefinitely. Exec should
+  // return after its post-exit idle grace, not wait for natural pipe EOF.
   const started = Date.now();
-  const { exitCode } = await exec("(sleep 5) &", cwd, { onData: () => {} });
+  const { exitCode } = await exec(command, cwd, { onData: () => {} });
   const elapsed = Date.now() - started;
 
   assert.equal(exitCode, 0);
   assert.ok(elapsed < 2000, `exec returned after ${elapsed}ms; expected early teardown`);
+});
+
+test("exec drains output that stays active after the direct child exits", async (t) => {
+  const { cwd, exec, trackBackgroundProcess } = createExecTestContext(t);
+  const writerSource = `
+let tick = 0;
+const writer = setInterval(() => {
+  tick += 1;
+  process.stdout.write(\`stdout-\${tick}\\n\`);
+  process.stderr.write(\`stderr-\${tick}\\n\`);
+  if (tick === 6) clearInterval(writer);
+}, 50);
+setInterval(() => {}, 1000);
+`;
+  const { command, pidPath } = backgroundNodeCommand(cwd, writerSource);
+  trackBackgroundProcess(pidPath);
+
+  const chunks: Buffer[] = [];
+  const started = Date.now();
+  const { exitCode } = await exec(command, cwd, { onData: (data) => chunks.push(data) });
+  const elapsed = Date.now() - started;
+  const output = Buffer.concat(chunks).toString("utf8");
+
+  assert.equal(exitCode, 0);
+  for (let tick = 1; tick <= 6; tick += 1) {
+    assert.ok(output.includes(`stdout-${tick}\n`), `missing stdout token ${tick}`);
+    assert.ok(output.includes(`stderr-${tick}\n`), `missing stderr token ${tick}`);
+  }
+  assert.ok(elapsed < 2000, `exec returned after ${elapsed}ms; expected idle teardown`);
+});
+
+test("exec returns a nonzero exit code", async (t) => {
+  const { cwd, exec } = createExecTestContext(t);
+
+  assert.deepEqual(await exec("exit 7", cwd, { onData: () => {} }), { exitCode: 7 });
+});
+
+test("exec rejects after its command timeout", async (t) => {
+  const { cwd, exec } = createExecTestContext(t);
+
+  await assert.rejects(
+    exec("sleep 5", cwd, { onData: () => {}, timeout: 0.05 }),
+    new Error("timeout:0.05"),
+  );
+});
+
+test("exec rejects when an in-flight command is aborted", async (t) => {
+  const { cwd, exec } = createExecTestContext(t);
+  const controller = new AbortController();
+  const abortTimer = setTimeout(() => controller.abort(), 50);
+  t.after(() => clearTimeout(abortTimer));
+
+  await assert.rejects(
+    exec("sleep 5", cwd, { onData: () => {}, signal: controller.signal }),
+    new Error("aborted"),
+  );
 });


### PR DESCRIPTION
## Summary
**TLDR**: This fixes an issue where a command called by the agent could hang indefinitely. I ran into this when the agent was running browser automation and opened a chrome subprocess. It would hang forever.

------

`createSandboxedBashOps.exec` previously waited for the child’s `"close"` event. Node may not emit `"close"` while a descendant still holds inherited stdout/stderr file descriptors, even after the direct child exits.

This occurs when programs such as Chrome spawn long-lived background processes. The bash operation can then remain pending indefinitely despite the original command having exited.

Immediately destroying stdout/stderr on `"exit"` avoids that hang, but it can truncate trailing bytes that Node has not yet delivered through the streams.

## Fix

Use the same post-exit stdio-draining behavior as Pi’s `waitForChildProcess` implementation:

- Record the direct child’s `"exit"` and exit code.
- Continue reading stdout and stderr after exit.
- Start a 100 ms post-exit idle grace period.
- Reset that grace period whenever another output chunk arrives.
- Resolve immediately when both streams end naturally.
- Destroy the pipe readers after the post-exit idle period so a quiet descendant cannot keep the command pending indefinitely.
- Clean up timeout, abort, process, and stream listeners through a single lifecycle.

This preserves trailing and continuously arriving output while still allowing commands to complete when daemonized descendants leave inherited descriptors open.

## Intentional tradeoff

A descendant that remains silent for longer than the 100 ms grace period is treated as detached. Output it produces later is not captured.

Waiting for arbitrarily delayed descendant output would require waiting for pipe EOF, which can hang forever when a daemon keeps the descriptors open. Increasing the grace period would only move that boundary. The 100 ms idle behavior intentionally matches Pi.

## Tests

Added coverage for:

- A daemonized descendant that keeps stdout/stderr open indefinitely.
- Stdout and stderr that remain active for approximately 300 ms after the direct child exits.
- Nonzero command exit codes.
- Command timeouts.
- In-flight aborts.

Verification:

- Formatting passes.
- Lint passes.
- TypeScript checking passes.
- All 27 tests pass.
- A manual test through the real macOS `sandbox-exec` wrapper captured all delayed stdout/stderr pairs and resolved approximately 100 ms after the final pair.
