### PR TITLE
feat: auto-allow git metadata paths for linked worktrees and submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .pi
 node_modules
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -18,11 +18,19 @@ These open significant security loopholes, so shouldn't be used in a sensitive c
 
 You may need to trial and error to find additional things you need to allow.
 
-When the session working directory is a linked git worktree or submodule checkout,
-the extension automatically allows the git metadata directories referenced by the
-`.git` file (including the shared `.git` directory for worktrees). This lets
-`git` commands work without manual config, but it is a deliberate sandbox
-relaxation scoped to paths git itself references.
+When the session working directory is anywhere inside a linked git worktree or
+submodule checkout, the extension asks git to validate the checkout and
+automatically allows the metadata directories it reports (including the shared
+`.git` directory for worktrees). This lets `git` commands work without manual
+config, but it is a deliberate sandbox relaxation scoped to paths git itself
+recognizes as repository metadata. Checkouts created with
+`git --separate-git-dir` do not have Git's reciprocal metadata pointer, so the
+extension asks for explicit approval before allowing their separate metadata
+directory. In a headless session, separate metadata remains blocked unless it
+is already covered by `filesystem.allowWrite`. Set `autoAllowGitMetadata` to
+`false` to disable all automatic Git metadata handling and rely only on explicit
+filesystem allowances. This feature requires `git` on the `PATH` that pi was
+launched with.
 
 ## Quickstart
 
@@ -77,6 +85,7 @@ Note below that the order of precedence for filesystem read and write are opposi
 ```json
 {
   "enabled": true,
+  "autoAllowGitMetadata": true, // Set false to disable automatic Git metadata access
   "permissionPromptTimeoutSeconds": 600, // Defaults to 10 minutes; 0 waits indefinitely
   "allowBrowserProcess": true,     // If you want to use agent-browser or similar Chrome setup
   "network": {

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ These open significant security loopholes, so shouldn't be used in a sensitive c
 
 You may need to trial and error to find additional things you need to allow.
 
+When the session working directory is a linked git worktree or submodule checkout,
+the extension automatically allows the git metadata directories referenced by the
+`.git` file (including the shared `.git` directory for worktrees). This lets
+`git` commands work without manual config, but it is a deliberate sandbox
+relaxation scoped to paths git itself references.
+
 ## Quickstart
 
 #### Prerequisites

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import { getAgentDir } from "@earendil-works/pi-coding-agent";
 
 export type SandboxConfig = Omit<SandboxRuntimeConfig, "network"> & {
   enabled?: boolean;
+  autoAllowGitMetadata?: boolean;
   permissionPromptTimeoutSeconds?: number;
   network?: NonNullable<SandboxRuntimeConfig["network"]> & {
     allowUnauthenticatedSocksProxy?: boolean;
@@ -26,6 +27,7 @@ export const DEFAULT_PERMISSION_PROMPT_TIMEOUT_SECONDS = 10 * 60;
 
 export const DEFAULT_CONFIG: SandboxConfig = {
   enabled: true,
+  autoAllowGitMetadata: true,
   permissionPromptTimeoutSeconds: DEFAULT_PERMISSION_PROMPT_TIMEOUT_SECONDS,
   network: {
     allowUnauthenticatedSocksProxy: process.platform === "darwin",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,7 @@ export default function (pi: ExtensionAPI) {
   let sandboxInitialized = false;
   const allowances: SessionAllowances = { domains: [], readPaths: [], writePaths: [] };
 
-  const effectiveAllowances = (cwd: string) => resolveAllowances(loadConfig(cwd), allowances);
+  const effectiveAllowances = (cwd: string) => resolveAllowances(loadConfig(cwd), allowances, cwd);
   const effectiveDomains = (cwd: string) => effectiveAllowances(cwd).domains;
   const effectiveReadPaths = (cwd: string) => effectiveAllowances(cwd).readPaths;
   const effectiveWritePaths = (cwd: string) => effectiveAllowances(cwd).writePaths;
@@ -64,7 +64,7 @@ export default function (pi: ExtensionAPI) {
   async function refreshSandbox(cwd: string): Promise<void> {
     if (!sandboxInitialized) return;
     try {
-      await reinitializeSandbox(loadConfig(cwd), allowances);
+      await reinitializeSandbox(loadConfig(cwd), allowances, cwd);
     } catch (error) {
       console.error(`Warning: Failed to reinitialize sandbox: ${error}`);
     }
@@ -116,7 +116,7 @@ export default function (pi: ExtensionAPI) {
     }
 
     try {
-      await initializeSandbox(config, allowances);
+      await initializeSandbox(config, allowances, ctx.cwd);
       if (setProxyEnvironment && supportsNodeEnvProxy(process.versions.node)) {
         process.env.NODE_USE_ENV_PROXY ??= "1";
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,9 @@ import {
   resolveWritePermission,
 } from "./policy.ts";
 import {
+  clearGitWorktreePathCache,
   createSandboxedBashOps,
+  discoverSeparateGitDirPath,
   extractBlockedWritePath,
   initializeSandbox,
   reinitializeSandbox,
@@ -36,6 +38,7 @@ import {
   type PermissionPromptResult,
   promptDomainBlock,
   promptReadBlock,
+  promptSeparateGitDirBlock,
   showPermissionPrompt,
   promptWriteBlock,
   warnIfAllDomainsAllowed,
@@ -99,6 +102,42 @@ export default function (pi: ExtensionAPI) {
     ctx.ui.setStatus("sandbox", ctx.ui.theme.fg("accent", formatSandboxStatus(config)));
   }
 
+  async function allowSeparateGitDir(
+    ctx: Parameters<typeof warnIfAllDomainsAllowed>[0],
+    config: ReturnType<typeof loadConfig>,
+  ): Promise<ReturnType<typeof loadConfig>> {
+    if (config.autoAllowGitMetadata === false || config.filesystem?.disabled) return config;
+
+    const separateGitDirPath = discoverSeparateGitDirPath(ctx.cwd);
+    if (!separateGitDirPath) return config;
+
+    // Explicit filesystem permissions take precedence over the confirmation prompt.
+    if (matchesPattern(separateGitDirPath, effectiveWritePaths(ctx.cwd))) return config;
+
+    if (!ctx.hasUI) {
+      ctx.ui.notify(
+        `Git metadata access is blocked for this separate-git-dir checkout: ${separateGitDirPath}. ` +
+          "Add it to filesystem.allowWrite or enable the sandbox with an interactive session.",
+        "warning",
+      );
+      return config;
+    }
+
+    const choice = await promptSeparateGitDirBlock(
+      pi,
+      ctx,
+      separateGitDirPath,
+      config.permissionPromptTimeoutSeconds,
+    );
+    if (choice.action === "abort") {
+      ctx.ui.notify(`Git metadata remains blocked: ${separateGitDirPath}`, "warning");
+      return config;
+    }
+
+    await applyChoice(choice.action, "write", choice.value, ctx.cwd);
+    return loadConfig(ctx.cwd);
+  }
+
   async function enableSandbox(
     ctx: Parameters<typeof warnIfAllDomainsAllowed>[0],
     setProxyEnvironment: boolean,
@@ -108,7 +147,7 @@ export default function (pi: ExtensionAPI) {
       return false;
     }
 
-    const config = loadConfig(ctx.cwd);
+    let config = loadConfig(ctx.cwd);
     const platform = process.platform;
     if (platform !== "darwin" && platform !== "linux") {
       ctx.ui.notify(`Sandbox not supported on ${platform}`, "warning");
@@ -116,6 +155,7 @@ export default function (pi: ExtensionAPI) {
     }
 
     try {
+      config = await allowSeparateGitDir(ctx, config);
       await initializeSandbox(config, allowances, ctx.cwd);
       if (setProxyEnvironment && supportsNodeEnvProxy(process.versions.node)) {
         process.env.NODE_USE_ENV_PROXY ??= "1";
@@ -150,6 +190,7 @@ export default function (pi: ExtensionAPI) {
         // Ignore cleanup errors.
       }
     }
+    clearGitWorktreePathCache();
     sandboxEnabled = false;
     sandboxInitialized = false;
     ctx.ui.setStatus("sandbox", "");
@@ -357,6 +398,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("session_shutdown", async () => {
+    clearGitWorktreePathCache();
     if (!sandboxInitialized) return;
     try {
       await SandboxManager.reset();

--- a/src/sandbox-runtime.ts
+++ b/src/sandbox-runtime.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
 
 import {
   SandboxManager,
@@ -33,13 +34,47 @@ const canonicalizeFilesystemPattern = (path: string) =>
 const canonicalizeFilesystemPatterns = (paths: string[]) =>
   unique(paths.map(canonicalizeFilesystemPattern));
 
+/** Discover git metadata directories for linked worktrees and submodules (.git is a file). */
+export function discoverGitWorktreePaths(cwd: string): string[] {
+  const gitFilePath = join(cwd, ".git");
+  if (!existsSync(gitFilePath)) return [];
+
+  try {
+    const stat = statSync(gitFilePath);
+    if (!stat.isFile()) return [];
+
+    const content = readFileSync(gitFilePath, "utf-8").trim();
+    const match = content.match(/^gitdir:\s*(.+)$/m);
+    if (!match) return [];
+
+    const worktreeGitDir = resolve(cwd, match[1].trim());
+    if (!existsSync(worktreeGitDir)) return [];
+
+    const paths = [worktreeGitDir];
+    const commondirFile = join(worktreeGitDir, "commondir");
+    if (existsSync(commondirFile)) {
+      const commonGitDir = resolve(worktreeGitDir, readFileSync(commondirFile, "utf-8").trim());
+      if (existsSync(commonGitDir)) {
+        paths.push(commonGitDir);
+      }
+    }
+
+    return unique(paths);
+  } catch {
+    return [];
+  }
+}
+
 export function resolveAllowances(
   config: SandboxConfig,
   allowances?: SessionAllowances,
+  cwd: string = process.cwd(),
 ): EffectiveAllowances {
+  const gitPaths = discoverGitWorktreePaths(cwd);
   const writePaths = unique([
     ...(config.filesystem?.allowWrite ?? []),
     ...(allowances?.writePaths ?? []),
+    ...gitPaths,
   ]);
 
   return {
@@ -60,8 +95,9 @@ export function createNetworkAskCallback(allowedDomains: string[]): SandboxAskCa
 export function buildRuntimeConfig(
   config: SandboxConfig,
   allowances?: SessionAllowances,
+  cwd: string = process.cwd(),
 ): SandboxRuntimeConfig {
-  const effective = resolveAllowances(config, allowances);
+  const effective = resolveAllowances(config, allowances, cwd);
 
   return {
     network: {
@@ -87,8 +123,9 @@ export function buildRuntimeConfig(
 export async function initializeSandbox(
   config: SandboxConfig,
   allowances?: SessionAllowances,
+  cwd: string = process.cwd(),
 ): Promise<void> {
-  const runtimeConfig = buildRuntimeConfig(config, allowances);
+  const runtimeConfig = buildRuntimeConfig(config, allowances, cwd);
   await SandboxManager.initialize(
     runtimeConfig,
     createNetworkAskCallback(runtimeConfig.network?.allowedDomains ?? []),
@@ -98,9 +135,10 @@ export async function initializeSandbox(
 export async function reinitializeSandbox(
   config: SandboxConfig,
   allowances: SessionAllowances,
+  cwd: string = process.cwd(),
 ): Promise<void> {
   await SandboxManager.reset();
-  await initializeSandbox(config, allowances);
+  await initializeSandbox(config, allowances, cwd);
 }
 
 export function supportsNodeEnvProxy(version: string): boolean {

--- a/src/sandbox-runtime.ts
+++ b/src/sandbox-runtime.ts
@@ -1,6 +1,6 @@
-import { spawn } from "node:child_process";
-import { existsSync, readFileSync, statSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { execFileSync, spawn } from "node:child_process";
+import { existsSync, lstatSync, readFileSync, statSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
 import {
   SandboxManager,
@@ -34,35 +34,199 @@ const canonicalizeFilesystemPattern = (path: string) =>
 const canonicalizeFilesystemPatterns = (paths: string[]) =>
   unique(paths.map(canonicalizeFilesystemPattern));
 
-/** Discover git metadata directories for linked worktrees and submodules (.git is a file). */
-export function discoverGitWorktreePaths(cwd: string): string[] {
-  const gitFilePath = join(cwd, ".git");
-  if (!existsSync(gitFilePath)) return [];
+function pathsReferToSameLocation(first: string, second: string): boolean {
+  return canonicalizePath(first) === canonicalizePath(second);
+}
 
+function pathIsWithin(path: string, parent: string): boolean {
+  const relativePath = relative(canonicalizePath(parent), canonicalizePath(path));
+  return (
+    relativePath === "" ||
+    (relativePath !== ".." && !relativePath.startsWith(`..${sep}`) && !isAbsolute(relativePath))
+  );
+}
+
+/** Walk ancestors to see if cwd is under a worktree/submodule (.git file) vs a regular clone. */
+export function ancestorHasGitMetadataFile(cwd: string): boolean {
   try {
-    const stat = statSync(gitFilePath);
-    if (!stat.isFile()) return [];
-
-    const content = readFileSync(gitFilePath, "utf-8").trim();
-    const match = content.match(/^gitdir:\s*(.+)$/m);
-    if (!match) return [];
-
-    const worktreeGitDir = resolve(cwd, match[1].trim());
-    if (!existsSync(worktreeGitDir)) return [];
-
-    const paths = [worktreeGitDir];
-    const commondirFile = join(worktreeGitDir, "commondir");
-    if (existsSync(commondirFile)) {
-      const commonGitDir = resolve(worktreeGitDir, readFileSync(commondirFile, "utf-8").trim());
-      if (existsSync(commonGitDir)) {
-        paths.push(commonGitDir);
+    let current = canonicalizePath(cwd);
+    while (true) {
+      const gitPath = join(current, ".git");
+      if (existsSync(gitPath)) {
+        const stat = lstatSync(gitPath);
+        if (stat.isFile()) return true;
+        return false;
       }
+      const parent = dirname(current);
+      if (parent === current) return false;
+      current = parent;
+    }
+  } catch {
+    return false;
+  }
+}
+
+export interface GitMetadataDiscovery {
+  /** Metadata paths that have been verified as belonging to this checkout. */
+  verifiedPaths: string[];
+  /** A separate-git-dir candidate that requires explicit user approval. */
+  separateGitDirPath: string | null;
+}
+
+const gitWorktreePathCache = new Map<string, GitMetadataDiscovery>();
+
+function readGitDirPointer(worktreeRoot: string): string | null {
+  try {
+    const gitFilePath = join(worktreeRoot, ".git");
+    if (!lstatSync(gitFilePath).isFile()) return null;
+    const content = readFileSync(gitFilePath, "utf-8");
+    const match = content.match(/^gitdir:\s*(.+)$/m);
+    return match ? resolve(worktreeRoot, match[1]!.trim()) : null;
+  } catch {
+    return null;
+  }
+}
+
+type GitMetadataValidation = "verified" | "separate-git-dir" | "invalid";
+
+function gitMetadataBelongsToWorktree(
+  worktreeRoot: string,
+  worktreeGitDir: string,
+  commonGitDir: string,
+): GitMetadataValidation {
+  try {
+    const gitFilePath = join(worktreeRoot, ".git");
+    const pointedGitDir = readGitDirPointer(worktreeRoot);
+    if (pointedGitDir === null || !pathsReferToSameLocation(pointedGitDir, worktreeGitDir)) {
+      return "invalid";
     }
 
-    return unique(paths);
+    // Linked worktree: git-dir differs from common-git-dir; validate gitdir back-pointer.
+    if (!pathsReferToSameLocation(worktreeGitDir, commonGitDir)) {
+      if (!pathsReferToSameLocation(dirname(worktreeGitDir), join(commonGitDir, "worktrees"))) {
+        return "invalid";
+      }
+      const backPointerPath = join(worktreeGitDir, "gitdir");
+      if (!lstatSync(backPointerPath).isFile()) return "invalid";
+      const backPointer = readFileSync(backPointerPath, "utf-8").replace(/\r?\n$/, "");
+      return backPointer.length > 0 &&
+        pathsReferToSameLocation(resolve(worktreeGitDir, backPointer), gitFilePath)
+        ? "verified"
+        : "invalid";
+    }
+
+    const configPath = join(worktreeGitDir, "config");
+    if (!lstatSync(configPath).isFile()) return "invalid";
+
+    let worktreeOutput: string;
+    try {
+      worktreeOutput = execFileSync(
+        "git",
+        ["config", "--file", configPath, "--path", "--null", "--get", "core.worktree"],
+        { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] },
+      );
+    } catch (error) {
+      // A valid `git init --separate-git-dir` checkout has no core.worktree entry.
+      // It is not reciprocally authenticated, so return it as a candidate for prompting.
+      return (error as { status?: number }).status === 1 ? "separate-git-dir" : "invalid";
+    }
+
+    if (
+      !worktreeOutput.endsWith("\0") ||
+      worktreeOutput.indexOf("\0") !== worktreeOutput.length - 1
+    ) {
+      return "invalid";
+    }
+    const configuredWorktree = worktreeOutput.slice(0, -1);
+    return configuredWorktree.length > 0 &&
+      pathsReferToSameLocation(resolve(worktreeGitDir, configuredWorktree), worktreeRoot)
+      ? "verified"
+      : "invalid";
   } catch {
-    return [];
+    return "invalid";
   }
+}
+
+function discoverGitMetadataViaGit(cwd: string): GitMetadataDiscovery {
+  try {
+    const gitEnvironment = { ...process.env };
+    delete gitEnvironment.GIT_DIR;
+    delete gitEnvironment.GIT_WORK_TREE;
+    delete gitEnvironment.GIT_COMMON_DIR;
+
+    const output = execFileSync(
+      "git",
+      ["-C", cwd, "rev-parse", "--show-toplevel", "--absolute-git-dir", "--git-common-dir"],
+      {
+        encoding: "utf-8",
+        env: gitEnvironment,
+        stdio: ["ignore", "pipe", "ignore"],
+      },
+    );
+    const lines = output.replace(/\r?\n$/, "").split(/\r?\n/);
+    if (lines.length !== 3 || lines.some((line) => line.length === 0)) {
+      return { verifiedPaths: [], separateGitDirPath: null };
+    }
+
+    const [worktreeRoot, worktreeGitDir, commonGitDirOutput] = lines;
+    if (!isAbsolute(worktreeRoot) || !isAbsolute(worktreeGitDir)) {
+      return { verifiedPaths: [], separateGitDirPath: null };
+    }
+    if (!pathIsWithin(cwd, worktreeRoot)) {
+      return { verifiedPaths: [], separateGitDirPath: null };
+    }
+
+    const commonGitDir = resolve(cwd, commonGitDirOutput);
+    if (!statSync(worktreeGitDir).isDirectory() || !statSync(commonGitDir).isDirectory()) {
+      return { verifiedPaths: [], separateGitDirPath: null };
+    }
+
+    const validation = gitMetadataBelongsToWorktree(worktreeRoot, worktreeGitDir, commonGitDir);
+    if (validation === "verified") {
+      return {
+        verifiedPaths: unique([worktreeGitDir, commonGitDir]),
+        separateGitDirPath: null,
+      };
+    }
+    if (validation === "separate-git-dir") {
+      return { verifiedPaths: [], separateGitDirPath: worktreeGitDir };
+    }
+  } catch {
+    // Fall through to an empty result when git is unavailable or rejects the checkout.
+  }
+  return { verifiedPaths: [], separateGitDirPath: null };
+}
+
+function cloneGitMetadataDiscovery(discovery: GitMetadataDiscovery): GitMetadataDiscovery {
+  return {
+    verifiedPaths: [...discovery.verifiedPaths],
+    separateGitDirPath: discovery.separateGitDirPath,
+  };
+}
+
+export function clearGitWorktreePathCache(): void {
+  gitWorktreePathCache.clear();
+}
+
+export function discoverGitMetadata(cwd: string): GitMetadataDiscovery {
+  const cacheKey = canonicalizePath(cwd);
+  const cached = gitWorktreePathCache.get(cacheKey);
+  if (cached !== undefined) return cloneGitMetadataDiscovery(cached);
+
+  const result = ancestorHasGitMetadataFile(cwd)
+    ? discoverGitMetadataViaGit(cwd)
+    : { verifiedPaths: [], separateGitDirPath: null };
+  gitWorktreePathCache.set(cacheKey, result);
+  return cloneGitMetadataDiscovery(result);
+}
+
+/** Discover verified metadata directories for linked worktrees and submodules (.git is a file). */
+export function discoverGitWorktreePaths(cwd: string): string[] {
+  return discoverGitMetadata(cwd).verifiedPaths;
+}
+
+export function discoverSeparateGitDirPath(cwd: string): string | null {
+  return discoverGitMetadata(cwd).separateGitDirPath;
 }
 
 export function resolveAllowances(
@@ -70,7 +234,7 @@ export function resolveAllowances(
   allowances?: SessionAllowances,
   cwd: string = process.cwd(),
 ): EffectiveAllowances {
-  const gitPaths = discoverGitWorktreePaths(cwd);
+  const gitPaths = config.autoAllowGitMetadata === false ? [] : discoverGitWorktreePaths(cwd);
   const writePaths = unique([
     ...(config.filesystem?.allowWrite ?? []),
     ...(allowances?.writePaths ?? []),
@@ -125,6 +289,7 @@ export async function initializeSandbox(
   allowances?: SessionAllowances,
   cwd: string = process.cwd(),
 ): Promise<void> {
+  clearGitWorktreePathCache();
   const runtimeConfig = buildRuntimeConfig(config, allowances, cwd);
   await SandboxManager.initialize(
     runtimeConfig,

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -346,6 +346,22 @@ export function promptWriteBlock(
   );
 }
 
+export function promptSeparateGitDirBlock(
+  pi: ExtensionAPI,
+  ctx: ExtensionContext,
+  path: string,
+  timeoutSeconds?: number,
+): Promise<PermissionPromptResult> {
+  return showPermissionPrompt(
+    pi,
+    ctx,
+    `🔧 Git metadata needs approval: "${path}" is outside the checkout`,
+    path,
+    (value) => validRule(value, matchesPattern(path, [value]), `path "${path}"`),
+    timeoutSeconds,
+  );
+}
+
 export function warnIfAllDomainsAllowed(ctx: ExtensionContext, config: SandboxConfig): void {
   if (!allowsAllDomains(config.network?.allowedDomains)) return;
   ctx.ui.notify(

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -20,6 +20,19 @@ test("omitted permission prompt timeout defaults to ten minutes", () => {
 
   assert.equal(DEFAULT_PERMISSION_PROMPT_TIMEOUT_SECONDS, 600);
   assert.equal(merged.permissionPromptTimeoutSeconds, DEFAULT_PERMISSION_PROMPT_TIMEOUT_SECONDS);
+  assert.equal(merged.autoAllowGitMetadata, true);
+});
+
+test("project config overrides the global Git metadata setting", () => {
+  const globalDisabled = mergeConfigLayers(DEFAULT_CONFIG, { autoAllowGitMetadata: false }, {});
+  const projectEnabled = mergeConfigLayers(
+    DEFAULT_CONFIG,
+    { autoAllowGitMetadata: false },
+    { autoAllowGitMetadata: true },
+  );
+
+  assert.equal(globalDisabled.autoAllowGitMetadata, false);
+  assert.equal(projectEnabled.autoAllowGitMetadata, true);
 });
 
 test("mergeConfigLayers combines configured arrays and deduplicates entries", () => {

--- a/test/sandbox-runtime.test.ts
+++ b/test/sandbox-runtime.test.ts
@@ -1,21 +1,85 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative, resolve } from "node:path";
 import test from "node:test";
 
+import { SandboxManager } from "@carderne/sandbox-runtime";
 import assert from "node:assert/strict";
 
 import { DEFAULT_CONFIG } from "../src/config.ts";
 import { canonicalizePath } from "../src/policy.ts";
 import {
+  ancestorHasGitMetadataFile,
   buildRuntimeConfig,
+  clearGitWorktreePathCache,
   discoverGitWorktreePaths,
+  discoverSeparateGitDirPath,
   extractBlockedWritePath,
+  initializeSandbox,
   resolveAllowances,
   supportsNodeEnvProxy,
 } from "../src/sandbox-runtime.ts";
 
 const NON_GIT_CWD = "/non-git-dir";
+
+function runGit(cwd: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).replace(/\r?\n$/, "");
+}
+
+function initializeRepository(repoDir: string): void {
+  mkdirSync(repoDir, { recursive: true });
+  runGit(repoDir, ["init", "--quiet"]);
+  runGit(repoDir, [
+    "-c",
+    "user.name=Pi Sandbox Tests",
+    "-c",
+    "user.email=pi-sandbox@example.invalid",
+    "commit",
+    "--quiet",
+    "--allow-empty",
+    "-m",
+    "Initial commit",
+  ]);
+}
+
+function createLinkedWorktree(tempDir: string): { mainRepo: string; worktreeDir: string } {
+  const mainRepo = join(tempDir, "main-repo");
+  const worktreeDir = join(tempDir, "linked-worktree");
+  initializeRepository(mainRepo);
+  runGit(mainRepo, ["worktree", "add", "--quiet", "-b", "test-worktree", worktreeDir]);
+  return { mainRepo, worktreeDir };
+}
+
+function createSeparateGitDirCheckout(tempDir: string): {
+  gitDir: string;
+  worktreeDir: string;
+} {
+  const gitDir = join(tempDir, "separate-git-dir");
+  const worktreeDir = join(tempDir, "separate-worktree");
+  runGit(tempDir, ["init", "--quiet", `--separate-git-dir=${gitDir}`, worktreeDir]);
+  return { gitDir, worktreeDir };
+}
+
+function withEnvironment(overrides: Record<string, string>, callback: () => void): void {
+  const previous = new Map<string, string | undefined>();
+  for (const [name, value] of Object.entries(overrides)) {
+    previous.set(name, process.env[name]);
+    process.env[name] = value;
+  }
+  try {
+    callback();
+  } finally {
+    for (const [name, value] of previous) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
+}
 
 test("buildRuntimeConfig adds session allowances without mutating config", () => {
   const runtime = buildRuntimeConfig(
@@ -94,95 +158,333 @@ test("supportsNodeEnvProxy observes Node release boundaries", () => {
   assert.equal(supportsNodeEnvProxy("24.0.0"), true);
 });
 
-test("discoverGitWorktreePaths discovers external worktree and common git directories", () => {
-  const tempDir = mkdtempSync(join(tmpdir(), "pi-sandbox-worktree-test-"));
+test("ancestorHasGitMetadataFile distinguishes worktrees from regular clones", () => {
+  clearGitWorktreePathCache();
+  const tempDir = mkdtempSync(join(tmpdir(), "pi-sandbox-ancestor-test-"));
   try {
     const mainRepo = join(tempDir, "main-repo");
-    const mainGit = join(mainRepo, ".git");
-    const worktreeGitDir = join(mainGit, "worktrees", "feature-branch");
-    const worktreeDir = join(tempDir, "worktrees", "feature-branch");
+    initializeRepository(mainRepo);
+    const nestedMainRepoDir = join(mainRepo, "src", "nested");
+    mkdirSync(nestedMainRepoDir, { recursive: true });
 
-    mkdirSync(worktreeGitDir, { recursive: true });
-    mkdirSync(worktreeDir, { recursive: true });
+    assert.equal(ancestorHasGitMetadataFile(mainRepo), false);
+    assert.equal(ancestorHasGitMetadataFile(nestedMainRepoDir), false);
 
-    writeFileSync(join(worktreeGitDir, "commondir"), "../..\n");
-    writeFileSync(join(worktreeDir, ".git"), `gitdir: ${worktreeGitDir}\n`);
+    const { worktreeDir } = createLinkedWorktree(tempDir);
+    const nestedWorktreeDir = join(worktreeDir, "src", "nested");
+    mkdirSync(nestedWorktreeDir, { recursive: true });
+    assert.equal(ancestorHasGitMetadataFile(worktreeDir), true);
+    assert.equal(ancestorHasGitMetadataFile(nestedWorktreeDir), true);
 
-    const discovered = discoverGitWorktreePaths(worktreeDir);
-    assert.deepEqual(discovered, [worktreeGitDir, mainGit]);
+    const forgedWorktree = join(tempDir, "forged-worktree");
+    mkdirSync(forgedWorktree, { recursive: true });
+    writeFileSync(join(forgedWorktree, ".git"), "gitdir: /tmp/does-not-matter\n");
+    assert.equal(ancestorHasGitMetadataFile(forgedWorktree), true);
 
-    // Relative gitdir path (common in real worktrees)
-    const relWorktreeGitDir = join(mainGit, "worktrees", "rel-branch");
-    const relWorktreeDir = join(tempDir, "worktrees", "rel-branch");
-    mkdirSync(relWorktreeGitDir, { recursive: true });
-    mkdirSync(relWorktreeDir, { recursive: true });
-    writeFileSync(join(relWorktreeGitDir, "commondir"), "../..\n");
-    writeFileSync(
-      join(relWorktreeDir, ".git"),
-      `gitdir: ../../main-repo/.git/worktrees/rel-branch\n`,
-    );
-    assert.deepEqual(discoverGitWorktreePaths(relWorktreeDir), [relWorktreeGitDir, mainGit]);
+    const symlinkForgedWorktree = join(tempDir, "symlink-forged-worktree");
+    mkdirSync(symlinkForgedWorktree, { recursive: true });
+    symlinkSync(join(worktreeDir, ".git"), join(symlinkForgedWorktree, ".git"));
+    assert.equal(ancestorHasGitMetadataFile(symlinkForgedWorktree), false);
 
-    // Worktree with absolute commondir and trailing whitespace / CRLF in .git
-    const absWorktreeGitDir = join(mainGit, "worktrees", "abs-branch");
-    const absWorktreeDir = join(tempDir, "worktrees", "abs-branch");
-    mkdirSync(absWorktreeGitDir, { recursive: true });
-    mkdirSync(absWorktreeDir, { recursive: true });
-    writeFileSync(join(absWorktreeGitDir, "commondir"), `${mainGit}\n`);
-    writeFileSync(join(absWorktreeDir, ".git"), `gitdir: ${absWorktreeGitDir}  \r\n`);
-    assert.deepEqual(discoverGitWorktreePaths(absWorktreeDir), [absWorktreeGitDir, mainGit]);
-
-    // Worktree without commondir returns only worktreeGitDir without escalating to parents
-    const noCommondirGitDir = join(tempDir, "isolated-gitdir");
-    const noCommondirWorktreeDir = join(tempDir, "isolated-worktree");
-    mkdirSync(noCommondirGitDir, { recursive: true });
-    mkdirSync(noCommondirWorktreeDir, { recursive: true });
-    writeFileSync(join(noCommondirWorktreeDir, ".git"), `gitdir: ${noCommondirGitDir}\n`);
-    assert.deepEqual(discoverGitWorktreePaths(noCommondirWorktreeDir), [noCommondirGitDir]);
-
-    // Non-existent gitdir pointer returns empty
-    const staleWorktreeDir = join(tempDir, "stale-worktree");
-    mkdirSync(staleWorktreeDir, { recursive: true });
-    writeFileSync(join(staleWorktreeDir, ".git"), `gitdir: ${join(tempDir, "does-not-exist")}\n`);
-    assert.deepEqual(discoverGitWorktreePaths(staleWorktreeDir), []);
-
-    // Malformed .git file returns empty
-    const malformedDir = join(tempDir, "malformed-worktree");
-    mkdirSync(malformedDir, { recursive: true });
-    writeFileSync(join(malformedDir, ".git"), "not a gitdir line\n");
-    assert.deepEqual(discoverGitWorktreePaths(malformedDir), []);
-
-    // Regular clone with .git directory returns empty
-    assert.deepEqual(discoverGitWorktreePaths(mainRepo), []);
-
-    // Non-git directory returns empty
-    const nonGitDir = join(tempDir, "plain-dir");
-    mkdirSync(nonGitDir, { recursive: true });
-    assert.deepEqual(discoverGitWorktreePaths(nonGitDir), []);
+    const plainDir = join(tempDir, "plain-dir");
+    mkdirSync(plainDir, { recursive: true });
+    assert.equal(ancestorHasGitMetadataFile(plainDir), false);
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
+    clearGitWorktreePathCache();
   }
 });
 
-test("resolveAllowances includes discovered git worktree paths", () => {
-  const tempDir = mkdtempSync(join(tmpdir(), "pi-sandbox-allowance-test-"));
+test("discoverGitWorktreePaths caches git discovery per cwd and returns independent array copies", () => {
+  clearGitWorktreePathCache();
+  const tempDir = mkdtempSync(join(tmpdir(), "pi-sandbox-git-cache-test-"));
   try {
-    const mainGit = join(tempDir, "main-repo", ".git");
-    const worktreeGitDir = join(mainGit, "worktrees", "task");
-    const worktreeDir = join(tempDir, "task-worktree");
+    const { worktreeDir } = createLinkedWorktree(tempDir);
+    const first = discoverGitWorktreePaths(worktreeDir);
+    assert.ok(first.length > 0);
 
-    mkdirSync(worktreeGitDir, { recursive: true });
-    mkdirSync(worktreeDir, { recursive: true });
+    const second = discoverGitWorktreePaths(worktreeDir);
+    assert.deepEqual(second, first);
+    assert.notEqual(second, first);
 
-    writeFileSync(join(worktreeGitDir, "commondir"), "../..\n");
-    writeFileSync(join(worktreeDir, ".git"), `gitdir: ${worktreeGitDir}\n`);
+    first.push("/corrupted-entry");
+    const third = discoverGitWorktreePaths(worktreeDir);
+    assert.deepEqual(third, second);
+    assert.equal(third.includes("/corrupted-entry"), false);
 
-    const effective = resolveAllowances(DEFAULT_CONFIG, undefined, worktreeDir);
-    assert.equal(effective.writePaths.includes(worktreeGitDir), true);
-    assert.equal(effective.writePaths.includes(mainGit), true);
-    assert.equal(effective.readPaths.includes(worktreeGitDir), true);
-    assert.equal(effective.readPaths.includes(mainGit), true);
+    clearGitWorktreePathCache();
+    const fourth = discoverGitWorktreePaths(worktreeDir);
+    assert.deepEqual(fourth, second);
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
+    clearGitWorktreePathCache();
+  }
+});
+
+test("initializeSandbox discards cached git discovery before building config", async () => {
+  clearGitWorktreePathCache();
+  const tempDir = mkdtempSync(join(tmpdir(), "pi-sandbox-git-init-cache-test-"));
+  try {
+    const { worktreeDir } = createLinkedWorktree(tempDir);
+    const first = discoverGitWorktreePaths(worktreeDir);
+    assert.ok(first.length > 0);
+
+    writeFileSync(join(worktreeDir, ".git"), "not a gitdir line\n");
+    assert.deepEqual(discoverGitWorktreePaths(worktreeDir), first);
+
+    try {
+      await initializeSandbox(
+        { ...DEFAULT_CONFIG, autoAllowGitMetadata: false },
+        undefined,
+        worktreeDir,
+      );
+    } catch {
+      // SandboxManager.initialize may fail without OS sandbox deps; cache must still be cleared first.
+    }
+
+    assert.deepEqual(discoverGitWorktreePaths(worktreeDir), []);
+  } finally {
+    try {
+      await SandboxManager.reset();
+    } catch {
+      // Ignore cleanup errors when initialize never succeeded.
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+    clearGitWorktreePathCache();
+  }
+});
+
+test("discoverGitWorktreePaths discovers linked worktree metadata from nested directories", () => {
+  clearGitWorktreePathCache();
+  const tempDir = mkdtempSync(join(tmpdir(), "pi-sandbox-worktree-test-"));
+  try {
+    const { mainRepo, worktreeDir } = createLinkedWorktree(tempDir);
+    const nestedWorktreeDir = join(worktreeDir, "src", "nested");
+    mkdirSync(nestedWorktreeDir, { recursive: true });
+
+    const worktreeGitDir = runGit(worktreeDir, ["rev-parse", "--absolute-git-dir"]);
+    const commonGitDir = resolve(
+      worktreeDir,
+      runGit(worktreeDir, ["rev-parse", "--git-common-dir"]),
+    );
+    const expected = [worktreeGitDir, commonGitDir];
+
+    assert.deepEqual(discoverGitWorktreePaths(worktreeDir), expected);
+    assert.deepEqual(discoverGitWorktreePaths(nestedWorktreeDir), expected);
+
+    const unrelatedRepo = join(tempDir, "unrelated-repo");
+    initializeRepository(unrelatedRepo);
+    withEnvironment({ GIT_COMMON_DIR: join(unrelatedRepo, ".git") }, () => {
+      assert.deepEqual(discoverGitWorktreePaths(nestedWorktreeDir), expected);
+    });
+    const unrelatedWorktree = join(tempDir, "unrelated-worktree");
+    runGit(unrelatedRepo, [
+      "worktree",
+      "add",
+      "--quiet",
+      "-b",
+      "unrelated-worktree",
+      unrelatedWorktree,
+    ]);
+    const unrelatedGitDir = runGit(unrelatedWorktree, ["rev-parse", "--absolute-git-dir"]);
+    withEnvironment({ GIT_DIR: unrelatedGitDir }, () => {
+      assert.deepEqual(discoverGitWorktreePaths(worktreeDir), expected);
+    });
+
+    const forgedWorktree = join(tempDir, "forged-worktree");
+    mkdirSync(forgedWorktree, { recursive: true });
+    writeFileSync(join(forgedWorktree, ".git"), `gitdir: ${worktreeGitDir}\n`);
+    assert.deepEqual(discoverGitWorktreePaths(forgedWorktree), []);
+
+    const symlinkForgedWorktree = join(tempDir, "symlink-forged-worktree");
+    mkdirSync(symlinkForgedWorktree, { recursive: true });
+    symlinkSync(join(worktreeDir, ".git"), join(symlinkForgedWorktree, ".git"));
+    assert.deepEqual(discoverGitWorktreePaths(symlinkForgedWorktree), []);
+
+    writeFileSync(
+      join(worktreeDir, ".git"),
+      `gitdir: ${relative(worktreeDir, worktreeGitDir)}\r\n`,
+    );
+    clearGitWorktreePathCache();
+    assert.deepEqual(discoverGitWorktreePaths(nestedWorktreeDir), expected);
+
+    const nestedMainRepoDir = join(mainRepo, "src", "nested");
+    mkdirSync(nestedMainRepoDir, { recursive: true });
+    assert.deepEqual(discoverGitWorktreePaths(nestedMainRepoDir), []);
+
+    const innerRepo = join(worktreeDir, "vendor", "inner-repo");
+    initializeRepository(innerRepo);
+    const nestedInnerRepoDir = join(innerRepo, "src", "nested");
+    mkdirSync(nestedInnerRepoDir, { recursive: true });
+    assert.deepEqual(discoverGitWorktreePaths(nestedInnerRepoDir), []);
+    withEnvironment({ GIT_WORK_TREE: worktreeDir }, () => {
+      assert.deepEqual(discoverGitWorktreePaths(nestedInnerRepoDir), []);
+    });
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+    clearGitWorktreePathCache();
+  }
+});
+
+test("discoverGitWorktreePaths identifies separate git dirs without auto-allowing them", () => {
+  clearGitWorktreePathCache();
+  const tempDir = mkdtempSync(join(tmpdir(), "pi-sandbox-separate-git-dir-test-"));
+  try {
+    const { gitDir, worktreeDir } = createSeparateGitDirCheckout(tempDir);
+    const nestedWorktreeDir = join(worktreeDir, "src", "nested");
+    mkdirSync(nestedWorktreeDir, { recursive: true });
+
+    const restrictiveConfig = {
+      ...DEFAULT_CONFIG,
+      filesystem: {
+        ...DEFAULT_CONFIG.filesystem!,
+        allowRead: [],
+        allowWrite: [],
+      },
+    };
+    const discoveredGitDir = discoverSeparateGitDirPath(nestedWorktreeDir);
+    assert.equal(discoveredGitDir, canonicalizePath(gitDir));
+    assert.deepEqual(discoverGitWorktreePaths(nestedWorktreeDir), []);
+
+    const automatic = resolveAllowances(restrictiveConfig, undefined, nestedWorktreeDir);
+    assert.equal(automatic.writePaths.includes(gitDir), false);
+    assert.equal(automatic.readPaths.includes(gitDir), false);
+
+    const explicitlyAllowed = resolveAllowances(
+      {
+        ...restrictiveConfig,
+        filesystem: { ...restrictiveConfig.filesystem, allowWrite: [gitDir] },
+      },
+      undefined,
+      nestedWorktreeDir,
+    );
+    assert.equal(explicitlyAllowed.writePaths.includes(gitDir), true);
+    assert.equal(explicitlyAllowed.readPaths.includes(gitDir), true);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+    clearGitWorktreePathCache();
+  }
+});
+
+test("discoverGitWorktreePaths discovers submodule metadata from nested directories", () => {
+  clearGitWorktreePathCache();
+  const tempDir = mkdtempSync(join(tmpdir(), "pi-sandbox-submodule-test-"));
+  try {
+    const submoduleSource = join(tempDir, "submodule-source");
+    const mainRepo = join(tempDir, "main-repo");
+    initializeRepository(submoduleSource);
+    initializeRepository(mainRepo);
+    runGit(mainRepo, [
+      "-c",
+      "protocol.file.allow=always",
+      "submodule",
+      "add",
+      "--quiet",
+      submoduleSource,
+      "modules/child",
+    ]);
+
+    const submoduleDir = join(mainRepo, "modules", "child");
+    const nestedSubmoduleDir = join(submoduleDir, "src", "nested");
+    mkdirSync(nestedSubmoduleDir, { recursive: true });
+    const gitDir = runGit(submoduleDir, ["rev-parse", "--absolute-git-dir"]);
+    const commonGitDir = resolve(
+      submoduleDir,
+      runGit(submoduleDir, ["rev-parse", "--git-common-dir"]),
+    );
+
+    assert.deepEqual(discoverGitWorktreePaths(nestedSubmoduleDir), [
+      ...new Set([gitDir, commonGitDir]),
+    ]);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+    clearGitWorktreePathCache();
+  }
+});
+
+test("discoverGitWorktreePaths rejects metadata paths that git does not validate", () => {
+  clearGitWorktreePathCache();
+  const tempDir = mkdtempSync(join(tmpdir(), "pi-sandbox-invalid-git-test-"));
+  try {
+    const arbitraryTarget = join(tempDir, "arbitrary-target");
+    const invalidCheckout = join(tempDir, "invalid-checkout");
+    mkdirSync(arbitraryTarget, { recursive: true });
+    mkdirSync(invalidCheckout, { recursive: true });
+    writeFileSync(join(invalidCheckout, ".git"), `gitdir: ${arbitraryTarget}\n`);
+    assert.deepEqual(discoverGitWorktreePaths(invalidCheckout), []);
+
+    const validTarget = join(tempDir, "valid-target");
+    const forgedCheckout = join(tempDir, "forged-checkout");
+    initializeRepository(validTarget);
+    mkdirSync(forgedCheckout, { recursive: true });
+    writeFileSync(join(forgedCheckout, ".git"), `gitdir: ${join(validTarget, ".git")}\n`);
+    assert.deepEqual(discoverGitWorktreePaths(forgedCheckout), []);
+    withEnvironment(
+      {
+        GIT_CONFIG_COUNT: "1",
+        GIT_CONFIG_KEY_0: "core.worktree",
+        GIT_CONFIG_VALUE_0: forgedCheckout,
+      },
+      () => {
+        assert.deepEqual(discoverGitWorktreePaths(forgedCheckout), []);
+      },
+    );
+
+    const staleCheckout = join(tempDir, "stale-checkout");
+    mkdirSync(staleCheckout, { recursive: true });
+    writeFileSync(join(staleCheckout, ".git"), `gitdir: ${join(tempDir, "missing")}\n`);
+    assert.deepEqual(discoverGitWorktreePaths(staleCheckout), []);
+
+    const malformedCheckout = join(tempDir, "malformed-checkout");
+    mkdirSync(malformedCheckout, { recursive: true });
+    writeFileSync(join(malformedCheckout, ".git"), "not a gitdir line\n");
+    assert.deepEqual(discoverGitWorktreePaths(malformedCheckout), []);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+    clearGitWorktreePathCache();
+  }
+});
+
+test("resolveAllowances includes worktree metadata discovered from a nested directory", () => {
+  clearGitWorktreePathCache();
+  const tempDir = mkdtempSync(join(tmpdir(), "pi-sandbox-allowance-test-"));
+  try {
+    const { worktreeDir } = createLinkedWorktree(tempDir);
+    const nestedWorktreeDir = join(worktreeDir, "src", "nested");
+    mkdirSync(nestedWorktreeDir, { recursive: true });
+    const gitPaths = discoverGitWorktreePaths(nestedWorktreeDir);
+    assert.equal(gitPaths.length, 2);
+
+    const effective = resolveAllowances(DEFAULT_CONFIG, undefined, nestedWorktreeDir);
+    for (const gitPath of gitPaths) {
+      assert.equal(effective.writePaths.includes(gitPath), true);
+      assert.equal(effective.readPaths.includes(gitPath), true);
+    }
+
+    const disabled = resolveAllowances(
+      {
+        ...DEFAULT_CONFIG,
+        autoAllowGitMetadata: false,
+        filesystem: {
+          ...DEFAULT_CONFIG.filesystem!,
+          allowWrite: ["/explicit-write"],
+        },
+      },
+      {
+        domains: [],
+        readPaths: [],
+        writePaths: ["/session-write"],
+      },
+      nestedWorktreeDir,
+    );
+    for (const gitPath of gitPaths) {
+      assert.equal(disabled.writePaths.includes(gitPath), false);
+      assert.equal(disabled.readPaths.includes(gitPath), false);
+    }
+    assert.equal(disabled.writePaths.includes("/explicit-write"), true);
+    assert.equal(disabled.writePaths.includes("/session-write"), true);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+    clearGitWorktreePathCache();
   }
 });

--- a/test/sandbox-runtime.test.ts
+++ b/test/sandbox-runtime.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
 import assert from "node:assert/strict";
@@ -6,17 +9,24 @@ import { DEFAULT_CONFIG } from "../src/config.ts";
 import { canonicalizePath } from "../src/policy.ts";
 import {
   buildRuntimeConfig,
+  discoverGitWorktreePaths,
   extractBlockedWritePath,
   resolveAllowances,
   supportsNodeEnvProxy,
 } from "../src/sandbox-runtime.ts";
 
+const NON_GIT_CWD = "/non-git-dir";
+
 test("buildRuntimeConfig adds session allowances without mutating config", () => {
-  const runtime = buildRuntimeConfig(DEFAULT_CONFIG, {
-    domains: ["example.com"],
-    readPaths: ["/read"],
-    writePaths: ["/write"],
-  });
+  const runtime = buildRuntimeConfig(
+    DEFAULT_CONFIG,
+    {
+      domains: ["example.com"],
+      readPaths: ["/read"],
+      writePaths: ["/write"],
+    },
+    NON_GIT_CWD,
+  );
   assert.equal(runtime.network?.allowedDomains?.includes("example.com"), true);
   assert.equal(runtime.filesystem?.allowRead?.includes("/read"), true);
   assert.equal(runtime.filesystem?.allowRead?.includes("/write"), true);
@@ -25,16 +35,20 @@ test("buildRuntimeConfig adds session allowances without mutating config", () =>
 });
 
 test("buildRuntimeConfig canonicalizes non-glob filesystem paths", () => {
-  const runtime = buildRuntimeConfig({
-    ...DEFAULT_CONFIG,
-    filesystem: {
-      ...DEFAULT_CONFIG.filesystem!,
-      denyRead: ["/tmp"],
-      allowRead: [],
-      allowWrite: ["/tmp"],
-      denyWrite: ["*.key"],
+  const runtime = buildRuntimeConfig(
+    {
+      ...DEFAULT_CONFIG,
+      filesystem: {
+        ...DEFAULT_CONFIG.filesystem!,
+        denyRead: ["/tmp"],
+        allowRead: [],
+        allowWrite: ["/tmp"],
+        denyWrite: ["*.key"],
+      },
     },
-  });
+    undefined,
+    NON_GIT_CWD,
+  );
 
   assert.deepEqual(runtime.filesystem?.denyRead, [canonicalizePath("/tmp")]);
   assert.equal(runtime.filesystem?.allowRead?.includes(canonicalizePath("/tmp")), true);
@@ -51,11 +65,15 @@ test("resolveAllowances makes configured and session write paths readable", () =
       allowWrite: ["/configured-write"],
     },
   };
-  const effective = resolveAllowances(config, {
-    domains: [],
-    readPaths: [],
-    writePaths: ["/session-write"],
-  });
+  const effective = resolveAllowances(
+    config,
+    {
+      domains: [],
+      readPaths: [],
+      writePaths: ["/session-write"],
+    },
+    NON_GIT_CWD,
+  );
 
   assert.deepEqual(effective.readPaths, ["/configured-write", "/session-write"]);
   assert.deepEqual(effective.writePaths, ["/configured-write", "/session-write"]);
@@ -74,4 +92,97 @@ test("supportsNodeEnvProxy observes Node release boundaries", () => {
   assert.equal(supportsNodeEnvProxy("22.21.0"), true);
   assert.equal(supportsNodeEnvProxy("23.9.0"), false);
   assert.equal(supportsNodeEnvProxy("24.0.0"), true);
+});
+
+test("discoverGitWorktreePaths discovers external worktree and common git directories", () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "pi-sandbox-worktree-test-"));
+  try {
+    const mainRepo = join(tempDir, "main-repo");
+    const mainGit = join(mainRepo, ".git");
+    const worktreeGitDir = join(mainGit, "worktrees", "feature-branch");
+    const worktreeDir = join(tempDir, "worktrees", "feature-branch");
+
+    mkdirSync(worktreeGitDir, { recursive: true });
+    mkdirSync(worktreeDir, { recursive: true });
+
+    writeFileSync(join(worktreeGitDir, "commondir"), "../..\n");
+    writeFileSync(join(worktreeDir, ".git"), `gitdir: ${worktreeGitDir}\n`);
+
+    const discovered = discoverGitWorktreePaths(worktreeDir);
+    assert.deepEqual(discovered, [worktreeGitDir, mainGit]);
+
+    // Relative gitdir path (common in real worktrees)
+    const relWorktreeGitDir = join(mainGit, "worktrees", "rel-branch");
+    const relWorktreeDir = join(tempDir, "worktrees", "rel-branch");
+    mkdirSync(relWorktreeGitDir, { recursive: true });
+    mkdirSync(relWorktreeDir, { recursive: true });
+    writeFileSync(join(relWorktreeGitDir, "commondir"), "../..\n");
+    writeFileSync(
+      join(relWorktreeDir, ".git"),
+      `gitdir: ../../main-repo/.git/worktrees/rel-branch\n`,
+    );
+    assert.deepEqual(discoverGitWorktreePaths(relWorktreeDir), [relWorktreeGitDir, mainGit]);
+
+    // Worktree with absolute commondir and trailing whitespace / CRLF in .git
+    const absWorktreeGitDir = join(mainGit, "worktrees", "abs-branch");
+    const absWorktreeDir = join(tempDir, "worktrees", "abs-branch");
+    mkdirSync(absWorktreeGitDir, { recursive: true });
+    mkdirSync(absWorktreeDir, { recursive: true });
+    writeFileSync(join(absWorktreeGitDir, "commondir"), `${mainGit}\n`);
+    writeFileSync(join(absWorktreeDir, ".git"), `gitdir: ${absWorktreeGitDir}  \r\n`);
+    assert.deepEqual(discoverGitWorktreePaths(absWorktreeDir), [absWorktreeGitDir, mainGit]);
+
+    // Worktree without commondir returns only worktreeGitDir without escalating to parents
+    const noCommondirGitDir = join(tempDir, "isolated-gitdir");
+    const noCommondirWorktreeDir = join(tempDir, "isolated-worktree");
+    mkdirSync(noCommondirGitDir, { recursive: true });
+    mkdirSync(noCommondirWorktreeDir, { recursive: true });
+    writeFileSync(join(noCommondirWorktreeDir, ".git"), `gitdir: ${noCommondirGitDir}\n`);
+    assert.deepEqual(discoverGitWorktreePaths(noCommondirWorktreeDir), [noCommondirGitDir]);
+
+    // Non-existent gitdir pointer returns empty
+    const staleWorktreeDir = join(tempDir, "stale-worktree");
+    mkdirSync(staleWorktreeDir, { recursive: true });
+    writeFileSync(join(staleWorktreeDir, ".git"), `gitdir: ${join(tempDir, "does-not-exist")}\n`);
+    assert.deepEqual(discoverGitWorktreePaths(staleWorktreeDir), []);
+
+    // Malformed .git file returns empty
+    const malformedDir = join(tempDir, "malformed-worktree");
+    mkdirSync(malformedDir, { recursive: true });
+    writeFileSync(join(malformedDir, ".git"), "not a gitdir line\n");
+    assert.deepEqual(discoverGitWorktreePaths(malformedDir), []);
+
+    // Regular clone with .git directory returns empty
+    assert.deepEqual(discoverGitWorktreePaths(mainRepo), []);
+
+    // Non-git directory returns empty
+    const nonGitDir = join(tempDir, "plain-dir");
+    mkdirSync(nonGitDir, { recursive: true });
+    assert.deepEqual(discoverGitWorktreePaths(nonGitDir), []);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("resolveAllowances includes discovered git worktree paths", () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "pi-sandbox-allowance-test-"));
+  try {
+    const mainGit = join(tempDir, "main-repo", ".git");
+    const worktreeGitDir = join(mainGit, "worktrees", "task");
+    const worktreeDir = join(tempDir, "task-worktree");
+
+    mkdirSync(worktreeGitDir, { recursive: true });
+    mkdirSync(worktreeDir, { recursive: true });
+
+    writeFileSync(join(worktreeGitDir, "commondir"), "../..\n");
+    writeFileSync(join(worktreeDir, ".git"), `gitdir: ${worktreeGitDir}\n`);
+
+    const effective = resolveAllowances(DEFAULT_CONFIG, undefined, worktreeDir);
+    assert.equal(effective.writePaths.includes(worktreeGitDir), true);
+    assert.equal(effective.writePaths.includes(mainGit), true);
+    assert.equal(effective.readPaths.includes(worktreeGitDir), true);
+    assert.equal(effective.readPaths.includes(mainGit), true);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
In linked git worktrees and submodule checkouts, .git is a pointer file referencing external metadata directories (including commondir for worktrees). Without access to these paths, git operations fail under the sandbox filesystem restrictions.

- Implement discoverGitWorktreePaths() to parse gitdir: and commondir targets from .git files (handling relative/absolute paths and CRLF).
- Thread cwd through allowance resolution and sandbox initialization so discovered git directories are automatically added to allowRead and allowWrite.
- Update README to document the scoped sandbox relaxation.
- Add comprehensive unit tests for worktree discovery and allowance resolution.