### PR TITLE
add config option to not sandbox user shell input

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Note below that the order of precedence for filesystem read and write are opposi
 ```json
 {
   "enabled": true,
+  "sandboxUserShell": false,       // Sandbox commands entered with `!`. Defaults to true
   "permissionPromptTimeoutSeconds": 600, // Defaults to 10 minutes; 0 waits indefinitely
   "allowBrowserProcess": true,     // If you want to use agent-browser or similar Chrome setup
   "network": {
@@ -114,7 +115,9 @@ Alt+S                            toggle sandboxing on/off for the session
 ## What it does
 
 **Bash commands** are wrapped with `sandbox-exec` (macOS) or `bubblewrap`
-(Linux) to enforce network and filesystem restrictions at the OS level.
+(Linux) to enforce network and filesystem restrictions at the OS level. Commands
+entered with `!` are sandboxed by default; set `sandboxUserShell` to `false` to
+leave those commands unsandboxed.
 
 **Read, write, and edit tool calls** are intercepted before execution and
 checked against the same filesystem policy. The OS-level sandbox cannot cover
@@ -139,7 +142,7 @@ extension reloads or pi restarts.
 
 | Rule | Behaviour |
 |------|-----------|
-| Domain not in `allowedDomains` | Prompted (bash and `!cmd`) |
+| Domain not in `allowedDomains` | Prompted (bash and `!cmd`, unless `sandboxUserShell` is disabled) |
 | Path not in `allowRead` or `allowWrite` | Prompted (read tool); granting adds to `allowRead` |
 | Path not in `allowWrite` | Prompted (write/edit tools and bash write failures) |
 | Path in `denyWrite` | Hard-blocked, no prompt |

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import { getAgentDir } from "@earendil-works/pi-coding-agent";
 
 export type SandboxConfig = Omit<SandboxRuntimeConfig, "network"> & {
   enabled?: boolean;
+  sandboxUserShell?: boolean;
   permissionPromptTimeoutSeconds?: number;
   network?: NonNullable<SandboxRuntimeConfig["network"]> & {
     allowUnauthenticatedSocksProxy?: boolean;
@@ -26,6 +27,7 @@ export const DEFAULT_PERMISSION_PROMPT_TIMEOUT_SECONDS = 10 * 60;
 
 export const DEFAULT_CONFIG: SandboxConfig = {
   enabled: true,
+  sandboxUserShell: true,
   permissionPromptTimeoutSeconds: DEFAULT_PERMISSION_PROMPT_TIMEOUT_SECONDS,
   network: {
     allowUnauthenticatedSocksProxy: process.platform === "darwin",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -246,6 +246,7 @@ export default function (pi: ExtensionAPI) {
     if (!sandboxEnabled || !sandboxInitialized) return;
 
     const config = loadConfig(ctx.cwd);
+    if (config.sandboxUserShell === false) return;
     for (const domain of extractDomainsFromCommand(event.command)) {
       if (!domainIsAllowed(domain, effectiveDomains(ctx.cwd))) {
         const choice = await promptDomainBlock(

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -15,11 +15,12 @@ import {
   mergeConfigLayers,
 } from "../src/config.ts";
 
-test("omitted permission prompt timeout defaults to ten minutes", () => {
+test("omitted settings use their defaults", () => {
   const merged = mergeConfigLayers(DEFAULT_CONFIG, {}, {});
 
   assert.equal(DEFAULT_PERMISSION_PROMPT_TIMEOUT_SECONDS, 600);
   assert.equal(merged.permissionPromptTimeoutSeconds, DEFAULT_PERMISSION_PROMPT_TIMEOUT_SECONDS);
+  assert.equal(merged.sandboxUserShell, true);
 });
 
 test("mergeConfigLayers combines configured arrays and deduplicates entries", () => {
@@ -78,17 +79,20 @@ test("mergeConfigLayers uses defaults only for arrays not configured by either f
     DEFAULT_CONFIG,
     {
       enabled: false,
+      sandboxUserShell: false,
       permissionPromptTimeoutSeconds: 30,
       filesystem: { allowWrite: [] },
     },
     {
       enabled: true,
+      sandboxUserShell: true,
       permissionPromptTimeoutSeconds: 0,
       allowBrowserProcess: true,
     },
   );
 
   assert.equal(merged.enabled, true);
+  assert.equal(merged.sandboxUserShell, true);
   assert.equal(merged.permissionPromptTimeoutSeconds, 0);
   assert.equal(merged.allowBrowserProcess, true);
   assert.deepEqual(merged.filesystem?.allowWrite, []);


### PR DESCRIPTION
When I run shell commands in Pi by starting a message with `!` or `!!`, I do not want this to be sandboxed. This PR adds a config option `sandboxUserShell` which turns off this behaviour when set to `false`. By default, user shell input is still sandboxed.