### PR TITLE
fix: expose bundled seccomp helper on Linux

### DIFF
--- a/src/sandbox-runtime.ts
+++ b/src/sandbox-runtime.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import {
   SandboxManager,
@@ -33,6 +34,15 @@ const canonicalizeFilesystemPattern = (path: string) =>
 const canonicalizeFilesystemPatterns = (paths: string[]) =>
   unique(paths.map(canonicalizeFilesystemPattern));
 
+function sandboxRuntimeReadPaths(platform: NodeJS.Platform): string[] {
+  if (platform !== "linux") return [];
+
+  // apply-seccomp executes inside the Bubblewrap namespace, so broad rules
+  // such as denyRead: ["/home"] must not hide the runtime's bundled helper.
+  const runtimeEntryUrl = import.meta.resolve("@carderne/sandbox-runtime");
+  return [fileURLToPath(new URL("../vendor/seccomp", runtimeEntryUrl))];
+}
+
 export function resolveAllowances(
   config: SandboxConfig,
   allowances?: SessionAllowances,
@@ -60,6 +70,7 @@ export function createNetworkAskCallback(allowedDomains: string[]): SandboxAskCa
 export function buildRuntimeConfig(
   config: SandboxConfig,
   allowances?: SessionAllowances,
+  platform: NodeJS.Platform = process.platform,
 ): SandboxRuntimeConfig {
   const effective = resolveAllowances(config, allowances);
 
@@ -72,7 +83,10 @@ export function buildRuntimeConfig(
     filesystem: {
       disabled: config.filesystem?.disabled,
       denyRead: canonicalizeFilesystemPatterns(config.filesystem?.denyRead ?? []),
-      allowRead: canonicalizeFilesystemPatterns(effective.readPaths),
+      allowRead: canonicalizeFilesystemPatterns([
+        ...effective.readPaths,
+        ...sandboxRuntimeReadPaths(platform),
+      ]),
       allowWrite: canonicalizeFilesystemPatterns(effective.writePaths),
       denyWrite: canonicalizeFilesystemPatterns(config.filesystem?.denyWrite ?? []),
     },

--- a/test/sandbox-runtime.test.ts
+++ b/test/sandbox-runtime.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test, { mock, type TestContext } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { SandboxManager } from "@carderne/sandbox-runtime";
 import assert from "node:assert/strict";
@@ -99,6 +100,16 @@ test("buildRuntimeConfig canonicalizes non-glob filesystem paths", () => {
   assert.equal(runtime.filesystem?.allowRead?.includes(canonicalizePath("/tmp")), true);
   assert.deepEqual(runtime.filesystem?.allowWrite, [canonicalizePath("/tmp")]);
   assert.deepEqual(runtime.filesystem?.denyWrite, ["*.key"]);
+});
+
+test("buildRuntimeConfig exposes the bundled seccomp helper on Linux", () => {
+  const runtime = buildRuntimeConfig(DEFAULT_CONFIG, undefined, "linux");
+  const runtimeEntryUrl = import.meta.resolve("@carderne/sandbox-runtime");
+  const seccompPath = canonicalizePath(
+    fileURLToPath(new URL("../vendor/seccomp", runtimeEntryUrl)),
+  );
+
+  assert.equal(runtime.filesystem?.allowRead?.includes(seccompPath), true);
 });
 
 test("resolveAllowances makes configured and session write paths readable", () => {


### PR DESCRIPTION
## Summary

Prevents Linux sandboxed commands from failing when a broad `denyRead` rule hides the bundled `apply-seccomp` binary.

## Fix

Resolve the installed sandbox runtime package instead of assuming a particular Pi agent directory, then automatically add its `vendor/seccomp` directory to the internal Linux read allowances.

Closes #69.