### PR TITLE
fix: preserve active proxy connections during permission updates

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,7 @@ import {
   createSandboxedBashOps,
   extractBlockedWritePath,
   initializeSandbox,
-  reinitializeSandbox,
+  updateSandboxConfig,
   resolveAllowances,
   type SessionAllowances,
   supportsNodeEnvProxy,
@@ -64,9 +64,9 @@ export default function (pi: ExtensionAPI) {
   async function refreshSandbox(cwd: string): Promise<void> {
     if (!sandboxInitialized) return;
     try {
-      await reinitializeSandbox(loadConfig(cwd), allowances);
+      updateSandboxConfig(loadConfig(cwd), allowances);
     } catch (error) {
-      console.error(`Warning: Failed to reinitialize sandbox: ${error}`);
+      console.error(`Warning: Failed to update sandbox configuration: ${error}`);
     }
   }
 

--- a/src/sandbox-runtime.ts
+++ b/src/sandbox-runtime.ts
@@ -2,15 +2,11 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import {
-  SandboxManager,
-  type SandboxAskCallback,
-  type SandboxRuntimeConfig,
-} from "@carderne/sandbox-runtime";
+import { SandboxManager, type SandboxRuntimeConfig } from "@carderne/sandbox-runtime";
 import { type BashOperations, getShellConfig } from "@earendil-works/pi-coding-agent";
 
 import { type SandboxConfig } from "./config.ts";
-import { canonicalizePath, domainIsAllowed } from "./policy.ts";
+import { canonicalizePath } from "./policy.ts";
 
 export interface SessionAllowances {
   domains: string[];
@@ -63,10 +59,6 @@ export function resolveAllowances(
   };
 }
 
-export function createNetworkAskCallback(allowedDomains: string[]): SandboxAskCallback {
-  return async ({ host }) => domainIsAllowed(host, allowedDomains);
-}
-
 export function buildRuntimeConfig(
   config: SandboxConfig,
   allowances?: SessionAllowances,
@@ -103,18 +95,15 @@ export async function initializeSandbox(
   allowances?: SessionAllowances,
 ): Promise<void> {
   const runtimeConfig = buildRuntimeConfig(config, allowances);
-  await SandboxManager.initialize(
-    runtimeConfig,
-    createNetworkAskCallback(runtimeConfig.network?.allowedDomains ?? []),
-  );
+  // The runtime checks its live allowlist. Permission prompts happen before
+  // execution; a callback capturing this initial list could re-allow removed domains.
+  await SandboxManager.initialize(runtimeConfig);
 }
 
-export async function reinitializeSandbox(
-  config: SandboxConfig,
-  allowances: SessionAllowances,
-): Promise<void> {
-  await SandboxManager.reset();
-  await initializeSandbox(config, allowances);
+export function updateSandboxConfig(config: SandboxConfig, allowances: SessionAllowances): void {
+  // Permission updates must not tear down the proxy used by concurrent commands.
+  // Network rules apply immediately; new commands pick up filesystem rules when wrapped.
+  SandboxManager.updateConfig(buildRuntimeConfig(config, allowances));
 }
 
 export function supportsNodeEnvProxy(version: string): boolean {

--- a/test/sandbox-network.test.ts
+++ b/test/sandbox-network.test.ts
@@ -1,0 +1,96 @@
+import { createServer, request } from "node:http";
+import type { AddressInfo } from "node:net";
+import test from "node:test";
+
+import { SandboxManager } from "@carderne/sandbox-runtime";
+import assert from "node:assert/strict";
+
+import { DEFAULT_CONFIG } from "../src/config.ts";
+import { initializeSandbox, updateSandboxConfig } from "../src/sandbox-runtime.ts";
+
+test(
+  "permission updates preserve the proxy and enforce the new allowlist",
+  {
+    skip: process.platform !== "darwin",
+    timeout: 15_000,
+  },
+  async (t) => {
+    let releaseResponse: (() => void) | undefined;
+    let responseStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      responseStarted = resolve;
+    });
+    const origin = createServer((req, res) => {
+      if (req.url === "/hold") {
+        res.write("before");
+        releaseResponse = () => res.end("after");
+      } else {
+        res.end("ok");
+      }
+    });
+    t.after(async () => {
+      releaseResponse?.();
+      origin.closeAllConnections();
+      origin.close();
+      await SandboxManager.reset();
+    });
+    await new Promise<void>((resolve) => origin.listen(0, "127.0.0.1", resolve));
+    const originPort = (origin.address() as AddressInfo).port;
+    const config = {
+      ...DEFAULT_CONFIG,
+      network: { ...DEFAULT_CONFIG.network!, allowedDomains: ["127.0.0.1"] },
+    };
+    await initializeSandbox(config);
+    const proxyPort = SandboxManager.getProxyPort();
+    const socksPort = SandboxManager.getSocksProxyPort();
+    const token = SandboxManager.getProxyAuthToken();
+    assert.ok(proxyPort);
+    assert.ok(socksPort);
+
+    function throughProxy(host: string, path = "/") {
+      return new Promise<{ status: number | undefined; body: string }>((resolve, reject) => {
+        const req = request(
+          {
+            host: "127.0.0.1",
+            port: proxyPort,
+            path: `http://${host}:${originPort}${path}`,
+            headers: token
+              ? { "Proxy-Authorization": `Basic ${Buffer.from(`srt:${token}`).toString("base64")}` }
+              : {},
+          },
+          (res) => {
+            let body = "";
+            res.on("data", (data) => {
+              body += data.toString();
+              if (path === "/hold") responseStarted?.();
+            });
+            res.on("error", reject);
+            res.on("end", () => resolve({ status: res.statusCode, body }));
+          },
+        );
+        req.on("error", reject);
+        req.end();
+      });
+    }
+
+    const pending = throughProxy("127.0.0.1", "/hold");
+    // Attach a handler immediately so a broken refresh reports a test failure,
+    // rather than an unhandled rejection from the interrupted connection.
+    pending.catch(() => {});
+    await started;
+    updateSandboxConfig(
+      { ...config, network: { ...config.network, allowedDomains: ["localhost"] } },
+      {
+        domains: [],
+        readPaths: ["/tmp/newly-allowed"],
+        writePaths: [],
+      },
+    );
+    assert.equal(SandboxManager.getProxyPort(), proxyPort);
+    assert.equal(SandboxManager.getSocksProxyPort(), socksPort);
+    assert.equal((await throughProxy("127.0.0.1")).status, 403);
+    assert.deepEqual(await throughProxy("localhost"), { status: 200, body: "ok" });
+    releaseResponse!();
+    assert.deepEqual(await pending, { status: 200, body: "beforeafter" });
+  },
+);


### PR DESCRIPTION
## Summary

Apply permission changes through the runtime's in-place configuration update instead of resetting and restarting its shared proxy. This keeps active connections and the proxy addresses held by running commands intact, preventing permission updates from interrupting Git-over-SSH.

Remove the callback that captured the initial allowlist so removed domains cannot be re-authorized by stale state. New commands pick up updated filesystem permissions; already-running commands retain their existing filesystem restrictions.

Verified with a real Git-over-SSH command across a permission update, an in-flight HTTP connection and allowlist regression test, all 29 extension tests, typechecking, and linting. The regression test currently runs on macOS.
