### PR TITLE
fix: isolate sandbox managers between agent sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,12 @@ or set it to `0` to wait indefinitely. A timeout never grants permission.
 
 **Session allowances** are held in memory only. They are never written to disk
 and the agent has no way to read or modify them. They are reset when the
-extension reloads or pi restarts.
+extension reloads or pi restarts. Parent agents and subagents have separate
+sandbox managers and session allowances; shutting down one does not affect another.
+
+Saved project or global permission changes are not broadcast to other running
+sessions' sandbox managers. Restart affected sessions to apply grants or revocations
+consistently.
 
 ### What is prompted vs. hard-blocked
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ci:test": "pnpm test"
   },
   "dependencies": {
-    "@carderne/sandbox-runtime": "^0.0.71"
+    "@carderne/sandbox-runtime": "^0.0.72"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "^0.80.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-sandbox",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "OS-level sandboxing for pi with interactive permission prompts",
   "keywords": [
     "pi-package",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
   .:
     dependencies:
       '@carderne/sandbox-runtime':
-        specifier: ^0.0.71
-        version: 0.0.71
+        specifier: ^0.0.72
+        version: 0.0.72
     devDependencies:
       '@earendil-works/pi-coding-agent':
         specifier: ^0.80.0
@@ -150,8 +150,8 @@ packages:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
-  '@carderne/sandbox-runtime@0.0.71':
-    resolution: {integrity: sha512-/3m2N6k5+MLYQyyL6bOByDa3FjvMZr5+st2vQQYOg9acCswPsvWDunnffBMqxoS2UYjNJoMJxChacWv9e5jr6w==}
+  '@carderne/sandbox-runtime@0.0.72':
+    resolution: {integrity: sha512-7GI5hDQ7vUHdkVsHHZ76kbVTzy2Wt0twcQhUDVpGG5mgn5vENpWXImU8kKFf+YifDHn7nSoltCqa1RAqZZbVtw==}
     engines: {node: '>=20.11.0'}
     hasBin: true
 
@@ -1294,7 +1294,7 @@ snapshots:
 
   '@babel/runtime@7.29.7': {}
 
-  '@carderne/sandbox-runtime@0.0.71':
+  '@carderne/sandbox-runtime@0.0.72':
     dependencies:
       '@pondwader/socks5-server': 1.0.10
       commander: 12.1.0

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { SandboxManager } from "@carderne/sandbox-runtime";
+import { createSandboxManager } from "@carderne/sandbox-runtime";
 import { type AgentToolResult, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
   createBashToolDefinition,
@@ -42,6 +42,7 @@ import {
 } from "./ui.ts";
 
 export default function (pi: ExtensionAPI) {
+  const sandboxManager = createSandboxManager();
   pi.registerFlag("no-sandbox", {
     description: "Disable OS-level sandboxing for bash commands",
     type: "boolean",
@@ -64,7 +65,7 @@ export default function (pi: ExtensionAPI) {
   async function refreshSandbox(cwd: string): Promise<void> {
     if (!sandboxInitialized) return;
     try {
-      updateSandboxConfig(loadConfig(cwd), allowances);
+      updateSandboxConfig(sandboxManager, loadConfig(cwd), allowances);
     } catch (error) {
       console.error(`Warning: Failed to update sandbox configuration: ${error}`);
     }
@@ -116,7 +117,7 @@ export default function (pi: ExtensionAPI) {
     }
 
     try {
-      await initializeSandbox(config, allowances);
+      await initializeSandbox(sandboxManager, config, allowances);
       if (setProxyEnvironment && supportsNodeEnvProxy(process.versions.node)) {
         process.env.NODE_USE_ENV_PROXY ??= "1";
       }
@@ -145,7 +146,7 @@ export default function (pi: ExtensionAPI) {
 
     if (sandboxInitialized) {
       try {
-        await SandboxManager.reset();
+        await sandboxManager.reset();
       } catch {
         // Ignore cleanup errors.
       }
@@ -174,6 +175,7 @@ export default function (pi: ExtensionAPI) {
         }
         return createBashToolDefinition(localCwd, {
           operations: createSandboxedBashOps(
+            sandboxManager,
             userShellPath,
             loadConfig(ctx.cwd).network?.sshProxy !== false,
           ),
@@ -270,6 +272,7 @@ export default function (pi: ExtensionAPI) {
     }
     return {
       operations: createSandboxedBashOps(
+        sandboxManager,
         userShellPath,
         loadConfig(ctx.cwd).network?.sshProxy !== false,
       ),
@@ -360,7 +363,7 @@ export default function (pi: ExtensionAPI) {
   pi.on("session_shutdown", async () => {
     if (!sandboxInitialized) return;
     try {
-      await SandboxManager.reset();
+      await sandboxManager.reset();
     } catch {
       // Ignore cleanup errors.
     }

--- a/src/sandbox-runtime.ts
+++ b/src/sandbox-runtime.ts
@@ -1,8 +1,9 @@
+import type { ISandboxManager, SandboxRuntimeConfig } from "@carderne/sandbox-runtime";
+
 import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { SandboxManager, type SandboxRuntimeConfig } from "@carderne/sandbox-runtime";
 import { type BashOperations, getShellConfig } from "@earendil-works/pi-coding-agent";
 
 import { type SandboxConfig } from "./config.ts";
@@ -91,19 +92,24 @@ export function buildRuntimeConfig(
 }
 
 export async function initializeSandbox(
+  manager: ISandboxManager,
   config: SandboxConfig,
   allowances?: SessionAllowances,
 ): Promise<void> {
   const runtimeConfig = buildRuntimeConfig(config, allowances);
   // The runtime checks its live allowlist. Permission prompts happen before
   // execution; a callback capturing this initial list could re-allow removed domains.
-  await SandboxManager.initialize(runtimeConfig);
+  await manager.initialize(runtimeConfig);
 }
 
-export function updateSandboxConfig(config: SandboxConfig, allowances: SessionAllowances): void {
+export function updateSandboxConfig(
+  manager: ISandboxManager,
+  config: SandboxConfig,
+  allowances: SessionAllowances,
+): void {
   // Permission updates must not tear down the proxy used by concurrent commands.
   // Network rules apply immediately; new commands pick up filesystem rules when wrapped.
-  SandboxManager.updateConfig(buildRuntimeConfig(config, allowances));
+  manager.updateConfig(buildRuntimeConfig(config, allowances));
 }
 
 export function supportsNodeEnvProxy(version: string): boolean {
@@ -210,7 +216,11 @@ function waitForChildProcess(child: ChildProcess): Promise<number | null> {
   });
 }
 
-export function createSandboxedBashOps(shellPath?: string, sshProxy = true): BashOperations {
+export function createSandboxedBashOps(
+  manager: ISandboxManager,
+  shellPath?: string,
+  sshProxy = true,
+): BashOperations {
   return {
     async exec(command, cwd, { onData, signal, timeout, env }) {
       if (!existsSync(cwd)) throw new Error(`Working directory does not exist: ${cwd}`);
@@ -221,15 +231,12 @@ export function createSandboxedBashOps(shellPath?: string, sshProxy = true): Bas
       // the sandbox network proxy. Install a shell function so ordinary
       // `ssh host` commands use the runtime's local SOCKS proxy too. This is
       // deliberately opt-in at the config layer, but enabled by default.
-      const socksProxyPort = sshProxy ? SandboxManager.getSocksProxyPort() : undefined;
+      const socksProxyPort = sshProxy ? manager.getSocksProxyPort() : undefined;
       const sshProxyCommand =
         process.platform === "darwin" && socksProxyPort !== undefined
           ? `ssh() { /usr/bin/ssh -o 'ProxyCommand=/usr/bin/nc -X 5 -x localhost:${socksProxyPort} %h %p' "$@"; }; `
           : "";
-      const wrappedCommand = await SandboxManager.wrapWithSandbox(
-        `${sshProxyCommand}${command}`,
-        shell,
-      );
+      const wrappedCommand = await manager.wrapWithSandbox(`${sshProxyCommand}${command}`, shell);
 
       const child = spawn(shell, [...args, wrappedCommand], {
         cwd,
@@ -269,7 +276,7 @@ export function createSandboxedBashOps(shellPath?: string, sshProxy = true): Bas
       } finally {
         if (timeoutHandle) clearTimeout(timeoutHandle);
         signal?.removeEventListener("abort", killProcessGroup);
-        SandboxManager.cleanupAfterCommand();
+        manager.cleanupAfterCommand();
       }
     },
   };

--- a/test/sandbox-network.test.ts
+++ b/test/sandbox-network.test.ts
@@ -2,7 +2,7 @@ import { createServer, request } from "node:http";
 import type { AddressInfo } from "node:net";
 import test from "node:test";
 
-import { SandboxManager } from "@carderne/sandbox-runtime";
+import { createSandboxManager } from "@carderne/sandbox-runtime";
 import assert from "node:assert/strict";
 
 import { DEFAULT_CONFIG } from "../src/config.ts";
@@ -15,6 +15,7 @@ test(
     timeout: 15_000,
   },
   async (t) => {
+    const manager = createSandboxManager();
     let releaseResponse: (() => void) | undefined;
     let responseStarted: (() => void) | undefined;
     const started = new Promise<void>((resolve) => {
@@ -32,7 +33,7 @@ test(
       releaseResponse?.();
       origin.closeAllConnections();
       origin.close();
-      await SandboxManager.reset();
+      await manager.reset();
     });
     await new Promise<void>((resolve) => origin.listen(0, "127.0.0.1", resolve));
     const originPort = (origin.address() as AddressInfo).port;
@@ -40,10 +41,10 @@ test(
       ...DEFAULT_CONFIG,
       network: { ...DEFAULT_CONFIG.network!, allowedDomains: ["127.0.0.1"] },
     };
-    await initializeSandbox(config);
-    const proxyPort = SandboxManager.getProxyPort();
-    const socksPort = SandboxManager.getSocksProxyPort();
-    const token = SandboxManager.getProxyAuthToken();
+    await initializeSandbox(manager, config);
+    const proxyPort = manager.getProxyPort();
+    const socksPort = manager.getSocksProxyPort();
+    const token = manager.getProxyAuthToken();
     assert.ok(proxyPort);
     assert.ok(socksPort);
 
@@ -79,6 +80,7 @@ test(
     pending.catch(() => {});
     await started;
     updateSandboxConfig(
+      manager,
       { ...config, network: { ...config.network, allowedDomains: ["localhost"] } },
       {
         domains: [],
@@ -86,8 +88,8 @@ test(
         writePaths: [],
       },
     );
-    assert.equal(SandboxManager.getProxyPort(), proxyPort);
-    assert.equal(SandboxManager.getSocksProxyPort(), socksPort);
+    assert.equal(manager.getProxyPort(), proxyPort);
+    assert.equal(manager.getSocksProxyPort(), socksPort);
     assert.equal((await throughProxy("127.0.0.1")).status, 403);
     assert.deepEqual(await throughProxy("localhost"), { status: 200, body: "ok" });
     releaseResponse!();

--- a/test/sandbox-runtime.test.ts
+++ b/test/sandbox-runtime.test.ts
@@ -38,7 +38,7 @@ function createExecTestContext(t: TestContext) {
 
   return {
     cwd,
-    exec: createSandboxedBashOps(undefined, false).exec,
+    exec: createSandboxedBashOps(SandboxManager, undefined, false).exec,
     trackBackgroundProcess: (pidPath: string) => backgroundPidPaths.push(pidPath),
   };
 }

--- a/test/session-isolation.test.ts
+++ b/test/session-isolation.test.ts
@@ -1,0 +1,114 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import assert from "node:assert/strict";
+
+import extension from "../src/extension.ts";
+
+type Handler = (event: any, ctx: ExtensionContext) => any;
+
+function session(cwd: string) {
+  const handlers = new Map<string, Handler>();
+  let bash: Parameters<ExtensionAPI["registerTool"]>[0] | undefined;
+  const errors: string[] = [];
+  const api = {
+    on: (name: string, handler: Handler) => handlers.set(name, handler),
+    registerTool: (tool: typeof bash) => {
+      if (tool?.name === "bash") bash = tool;
+    },
+    registerFlag: () => {},
+    registerShortcut: () => {},
+    registerCommand: () => {},
+    getFlag: () => false,
+  } as unknown as ExtensionAPI;
+  const ctx = {
+    cwd,
+    hasUI: false,
+    ui: {
+      notify: (message: string, level: string) => {
+        if (level === "error") errors.push(message);
+      },
+      setStatus: () => {},
+      theme: { fg: (_color: string, text: string) => text },
+    },
+  } as unknown as ExtensionContext;
+  extension(api);
+  return {
+    async start() {
+      await handlers.get("session_start")!({ reason: "startup" }, ctx);
+      assert.deepEqual(errors, []);
+    },
+    async shutdown() {
+      await handlers.get("session_shutdown")!({ reason: "quit" }, ctx);
+    },
+    async bash(command: string) {
+      const result = await bash!.execute(
+        "test",
+        { command, timeout: 5 },
+        undefined,
+        undefined,
+        ctx,
+      );
+      return result.content
+        .filter((part) => part.type === "text")
+        .map((part) => part.text)
+        .join("\n");
+    },
+    async userBash(command: string) {
+      const result = await handlers.get("user_bash")!({ command, cwd }, ctx);
+      assert.ok(result.operations);
+      let output = "";
+      const execution = await result.operations.exec(command, cwd, {
+        timeout: 5,
+        env: { ...process.env },
+        onData: (data: Buffer) => {
+          output += data.toString();
+        },
+      });
+      assert.equal(execution.exitCode, 0, output);
+      return output;
+    },
+  };
+}
+
+test(
+  "a subagent shutdown does not stop its parent's bash or user shell",
+  {
+    skip: process.platform !== "darwin",
+    timeout: 15_000,
+  },
+  async (t) => {
+    const root = mkdtempSync(join(tmpdir(), "pi-sandbox-sessions-"));
+    const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = join(root, "agent");
+    mkdirSync(process.env.PI_CODING_AGENT_DIR);
+    writeFileSync(
+      join(process.env.PI_CODING_AGENT_DIR, "sandbox.json"),
+      JSON.stringify({
+        enabled: true,
+        network: { allowedDomains: ["localhost"], deniedDomains: [] },
+        filesystem: { denyRead: [], allowRead: [], allowWrite: [root], denyWrite: [] },
+      }),
+    );
+    const parent = session(root);
+    const child = session(root);
+    t.after(async () => {
+      await Promise.all([parent.shutdown(), child.shutdown()]);
+      if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+      else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+      rmSync(root, { recursive: true, force: true });
+    });
+    await Promise.all([parent.start(), child.start()]);
+    const command = `printf '%s' "$GIT_SSH_COMMAND"`;
+    const parentProxy = await parent.bash(command);
+    assert.match(parentProxy, /ProxyCommand/);
+    assert.notEqual(parentProxy, await child.bash(command));
+    await child.shutdown();
+    assert.equal(await parent.bash(command), parentProxy);
+    assert.equal(await parent.userBash(command), parentProxy);
+  },
+);


### PR DESCRIPTION
## Summary

Create one sandbox manager per extension instance and pass it through initialization, permission updates, both shell paths, and teardown. A subagent's shutdown no longer resets the parent's proxy or shares its session permissions.

Uses published `@carderne/sandbox-runtime@0.0.72` from https://github.com/carderne/sandbox-runtime/pull/20. Updates the lockfile and prepares pi-sandbox 0.6.8. Documents that saved permission changes are not broadcast to other already-running managers.

## Validation

- Clean install from the published runtime package: all 30 tests, typecheck, lint, formatting, and frozen-lockfile install passed.
- Pi SDK 0.85.1 and pi-subagents 0.19.0: actual TTL cleanup and manager disposal preserved parent/sibling HTTPS traffic and subsequent Git-over-SSH through both shell paths. Proxy descriptors closed on child disposal.
- The lifecycle check used real SDK sessions attached to manager records with aged completion timestamps, rather than waiting ten minutes or making LLM calls. No lifecycle or sandbox mocks.
